### PR TITLE
fix: a heavy sound is heavy under the name heaviness has

### DIFF
--- a/quranic_phonemizer/rules/noon_sakinah.py
+++ b/quranic_phonemizer/rules/noon_sakinah.py
@@ -145,12 +145,12 @@ def _merge(rule: Rule, at: SlotId, host, *, ghunnah: bool) -> Verdict:
 
 @dataclass(frozen=True, slots=True)
 class IkhfaaWeight:
-    """Ikhfaa haqiqi's hum is heavy before an istilaa letter, the same set
-    `Weight` reads for tafkheem -- its own edge, not a `TAFKHEEM` one."""
+    """Ikhfaa haqiqi's hum is heavy before an istilaa letter: the same set
+    `Weight` reads, naming the same rule it names."""
 
     followers: Followers
     always_heavy: frozenset[L] = frozenset()
-    rule: Rule = Rule.IKHFAA_HAQIQI
+    rule: Rule = Rule.TAFKHEEM
     phase: Phase = Phase.COLOUR
     triggers: frozenset = field(default=frozenset({L.NOON}))
 
@@ -168,8 +168,7 @@ class IkhfaaWeight:
             return None  # izhar, iqlab or idgham owns this pair instead
         return Verdict(
             Occurrence(
-                mint(Rule.IKHFAA_HAQIQI, at, variant=1), Rule.IKHFAA_HAQIQI,
-                Participants(at, following.id),
+                mint(Rule.TAFKHEEM, at), Rule.TAFKHEEM, Participants(at)
             ),
             (Recolour(at, Aspect.CONSONANT, SoundFeature.EMPHATIC, True),),
         )

--- a/tests/nasal/test_ikhfaa_haqiqi.py
+++ b/tests/nasal/test_ikhfaa_haqiqi.py
@@ -44,6 +44,19 @@ TANWEEN_ACROSS_A_BOUNDARY = [
 ]
 
 
+#: The sites above where the letter doing the hiding is one of istilaa, so the
+#: hum takes its weight. A heavy sound is heavy under one name, and the name is
+#: tafkheem.
+HEAVY_HUM = frozenset(
+    {"7:192", "56:29", "37:92", "7:14", "7:119",
+     "69:6", "25:39", "51:53", "4:57", "16:117"}
+)
+
+
+def _hum_rules(ref: str) -> set[str]:
+    return {"ikhfaa_haqiqi"} | ({"tafkheem"} if ref in HEAVY_HUM else set())
+
+
 #: One site per tanween mark, to say which character the rule is read off.
 EACH_TANWEEN_MARK = [
     ("20:20", (4, 5), "ٌ"),   # حَيَّةٌ تَسْعَىٰ
@@ -58,7 +71,7 @@ def test_every_hiding_letter_hides_a_written_noon(ref, word, expected):
     r = reading(site, isolated=word)
     assert r.phonemes(word) == expected
     assert "ikhfaa_haqiqi" in r.rules_on_char(word, "ن")
-    assert r.rules_on_sound(word, "ŋ") == {"ikhfaa_haqiqi"}
+    assert r.rules_on_sound(word, "ŋ") == _hum_rules(ref)
 
 
 @pytest.mark.parametrize(
@@ -68,7 +81,7 @@ def test_every_hiding_letter_hides_a_tanween_noon(ref, words, expected):
     first, last = words
     r = reading(Site(hafs=(ref, words)), ibtidaa=first, waqf=last)
     assert (r.phonemes(first), r.phonemes(last)) == expected
-    assert r.rules_on_sound(first, "ŋ") == {"ikhfaa_haqiqi"}
+    assert r.rules_on_sound(first, "ŋ") == _hum_rules(ref)
 
 
 @pytest.mark.parametrize(("ref", "words", "mark"), EACH_TANWEEN_MARK)
@@ -84,7 +97,8 @@ def test_a_noon_is_hidden_when_the_hiding_letter_starts_a_word(r):
     assert r.phonemes(4) == "miŋ"
     assert r.phonemes(5) == "ðˤuluma:t"
     assert "ikhfaa_haqiqi" in r.rules_on_char(4, "ن")
-    assert r.rules_on_sound(4, "ŋ") == {"ikhfaa_haqiqi"}
+    # the zaa hiding it is a letter of istilaa, so the hum is heavy
+    assert r.rules_on_sound(4, "ŋ") == {"ikhfaa_haqiqi", "tafkheem"}
 
 
 @for_each_riwayah(HEENIN, ibtidaa=19, wasl=19)
@@ -105,4 +119,6 @@ def test_the_heavy_hiding_toggle_defaults_off():
     on = reading(MANDUD, extra_phonemes=("emphatic_ikhfaa",), isolated=2)
     assert off.phonemes(2) == "maŋdˤu:dQ"
     assert on.phonemes(2) == "maŋˤdˤu:dQ"
-    assert on.rules_on_sound(2, "ŋˤ") == {"ikhfaa_haqiqi"}
+    # the toggle spends a character on the weight; the rule names it either way
+    assert off.rules_on_sound(2, "ŋ") == {"ikhfaa_haqiqi", "tafkheem"}
+    assert on.rules_on_sound(2, "ŋˤ") == {"ikhfaa_haqiqi", "tafkheem"}


### PR DESCRIPTION
A hidden noon leaves a hum, and before a letter of istilaa that hum is heavy. The engine already knew: `IkhfaaWeight` recolours the sound emphatic, and the alphabet spends `ŋˤ` on it when `emphatic_ikhfaa` is asked for. What it did not do was name the weight — it minted a second `ikhfaa_haqiqi` occurrence instead, so a consumer reading the rules off that noon saw the hiding twice and the heaviness not at all.

The occurrence is now `TAFKHEEM`, with the noon as its only participant, the same shape `Emphasis` mints. The rule fires whether or not the notation spends a character on it, exactly as `emphatic_fatha` does — the toggle controls the token, never the reading. Nothing else moves: no phoneme changes, and the two rules were already firing at the same sites.

The cost of the old name was paid downstream. The Inspector had grown its own heavy-ikhfaa detector — a set of istilaa phones, a next-phone lookahead, and a `tafkheem` bar drawn on a cell whose producer rules said `ikhfaa` alone. That is a reading the producer had withheld, decided in the renderer, and it can go now that the cell carries both names.

Test expectations move with it: the ten ikhfaa sites whose hiding letter is one of istilaa now assert both rules, named in one place rather than repeated per case. All eight gates green.