### PR TITLE
feat: the madd an ibdal writes names the hamza it is written on

### DIFF
--- a/quranic_phonemizer/phonemize/recited.py
+++ b/quranic_phonemizer/phonemize/recited.py
@@ -83,7 +83,7 @@ def write_recited(
     sounds = dict(performance.sounds)
     occurrences = {o.id: o for o in performance.occurrences}
     started = _slots_by_rule(performance, Rule.WASL_START)
-    sources = _source_graphemes(inscription)
+    sources = _source_graphemes(inscription, performance)
     signs = _stop_signs_by_word(score, inscription)
 
     out: list[RenderGlyph] = []
@@ -218,7 +218,7 @@ def _write_vowel(sound: Vowel, sound_id, slot_id, fact_glyphs, pen: Pen):
         )
 
 
-def _source_graphemes(inscription: Inscription) -> dict:
+def _source_graphemes(inscription: Inscription, performance: Performance) -> dict:
     """Every `Evidences` edge, keyed by (slot, fact): a base letter, a
     shadda, a haraka and its carrier each cite only their own source glyph.
     A `Decorates`/`Attests` edge names no fact; not part of this."""
@@ -228,7 +228,23 @@ def _source_graphemes(inscription: Inscription) -> dict:
         if fact not in _CONSONANT_FACTS and fact not in VOWEL_FACTS:
             continue
         out.setdefault((spelling.slot, fact), []).append(spelling.grapheme)
+    for carrier, quiescent in _ibdal_carriers(performance):
+        out.setdefault((carrier, SlotFact.VOWEL_LENGTH), []).extend(
+            out.get((quiescent, SlotFact.LETTER), ())
+        )
     return {key: tuple(graphemes) for key, graphemes in out.items()}
+
+
+def _ibdal_carriers(performance: Performance):
+    """(lengthened slot, the quiescent hamza it carries) for each ibdal.
+
+    The rasm writes no length on the prosthetic hamza, so the letter the
+    rule silences is the one the reading writes that length on."""
+    return [
+        (occurrence.parts.source, occurrence.parts.host)
+        for occurrence in performance.occurrences
+        if occurrence.rule is Rule.IBDAL_HAMZA and occurrence.parts.host is not None
+    ]
 
 
 def _fact_glyphs(fact_glyphs: dict, slot_id, fact: SlotFact) -> tuple:

--- a/tests/laws/test_recited_text.py
+++ b/tests/laws/test_recited_text.py
@@ -89,3 +89,19 @@ def test_a_kept_letter_names_its_source_glyph(hafs, pen):
     glyphs = _write(hafs, pen, "1:1:1")
     kept = [g for g in glyphs if g.kind is GlyphKind.BASE]
     assert kept and all(g.from_glyphs for g in kept)
+
+
+@pytest.mark.parametrize(
+    "ref, quiescent, carrier", [("10:15:11", "ئ", "ى"), ("2:283:16", "ؤ", "و")]
+)
+def test_an_ibdal_madd_letter_names_the_hamza_it_carries(hafs, pen, ref, quiescent, carrier):
+    # ٱئْتِ started on is إِىٓتْ: the length is written where the quiescent
+    # hamza stands, so that hamza is the glyph the madd letter comes from.
+    session = phonemize_request(hafs, ref)
+    chars = {g.id: g.char for g in session.inscription.graphemes}
+    glyphs = write_recited(
+        session.score, session.inscription, session.performance, pen
+    )
+    written = [g for g in glyphs if g.char == carrier]
+    assert written, f"{ref} writes no {carrier}"
+    assert [chars[i] for i in written[0].from_glyphs] == [quiescent]


### PR DESCRIPTION
Started on, `ٱئْتِ` is read `إِىٓتِ`: the prosthetic hamza takes a kasra, that kasra lengthens, and the quiescent hamza after it is the letter the length is written on. The recited text already spelt the yaa, but as an insertion — nothing in the rasm evidences length on the prosthetic hamza, so `_write_vowel` had no source glyph to cite, and a correspondence a reader plainly sees was left unsaid by the projection.

`SoftenedHamza` already records both slots in its occurrence, so the length can cite the letter the rule silenced. `_source_graphemes` now reads those occurrences alongside the inscription's own edges; the writer itself is untouched. The recited text is identical character for character — only `from_glyphs` on the madd letter and its sign moves, from empty to the hamza it stands on.

What this buys is downstream: a consumer partitioning a word into per-character cells can show that hamza as the letter it is read as, instead of greying it and inventing a separate cell beside it. All eight gates pass.