### PR TITLE
feat: add the Warsh naql vertical

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -117,15 +117,17 @@ around the internal naql.
 `tests/conformance/test_warsh_registers.py` asserts the mechanical latent
 register generated from the supplied script families and canonical hosts:
 
-- 1,868 within-ayah latent boundaries, every one after a matching written
-  moved haraka or a tanwin host: 1,592 written-haraka qata forms (A/I/U),
-  103 damm-stroke forms, and 173 badal forms.
-- 325 adjacent-ayah latent edges: 323 tanwin-final hosts, the one written
+- 1,658 within-ayah short-qata boundaries, every one after a matching written
+  moved haraka or a tanwin host: 1,589 written-haraka forms (A/I/U) and
+  69 damm-stroke forms.
+- 308 adjacent-ayah short-qata edges: 306 tanwin-final hosts, the one written
   moved haraka of `وَانْحَرِ` before 108:3, and one spelled-opening edge at
   canonical 29:1 -> 29:2. Five further latent verse starts open a surah and
   join nothing. The spelled-opening edge does not perform naql: a
   disjoined-letter opening ends as it would at a pause, so `اَحَسِبَ` keeps
   its restored qata even when the reader runs on.
+- The 227 initial badal forms (177 A, 47 U, and 3 I) are deferred to the
+  madd-badal vertical. Ordinary naql does not transfer their long nucleus.
 - The article register is exactly the documented 1,307: 1,283 written
   article alifs (955 wasl-marked, 328 prefixed bare), 22 suppressed-alif
   prefix forms, and the two interrogative tokens; the reviewed long bases

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -96,9 +96,6 @@ against the canonical derivation, whose closed disagreements are the passive
 
 Known residue deferred to later verticals:
 
-- Article words carrying internal naql (`وَالَارْضِ` and family) do not yet
-  project their wasl onset; the naql vertical owns them, and the canonical
-  register carries their count meanwhile.
 - The `التي` family is written without its geminate lam in this source and
   currently reads a single lam; its start quality is already the article's A.
 - The joined outcomes of the sixteen silent-qata words use the connected
@@ -109,6 +106,41 @@ Known residue deferred to later verticals:
   are executable above; the lexical-host family is supplied per site by the
   source linking haraka and still needs a morphology-backed generator to be
   counted mechanically.
+
+## Warsh naql registers
+
+The naql vertical cleared the earlier article residue: `وَالَارْضِ` and its
+family now project their wasl onset, the carried article vowel, and the
+`naql` annotation, so `hamza_wasl_silent`/`hamza_wasl_fatha` behave normally
+around the internal naql.
+
+`tests/conformance/test_warsh_registers.py` asserts the mechanical latent
+register generated from the supplied script families and canonical hosts:
+
+- 1,868 within-ayah latent boundaries, every one after a matching written
+  moved haraka or a tanwin host: 1,592 written-haraka qata forms (A/I/U),
+  103 damm-stroke forms, and 173 badal forms.
+- 325 adjacent-ayah latent edges: 323 tanwin-final hosts, the one written
+  moved haraka of `وَانْحَرِ` before 108:3, and one spelled-opening edge at
+  canonical 29:1 -> 29:2. Five further latent verse starts open a surah and
+  join nothing. The spelled-opening edge does not perform naql: a
+  disjoined-letter opening ends as it would at a pause, so `اَحَسِبَ` keeps
+  its restored qata even when the reader runs on.
+- The article register is exactly the documented 1,307: 1,283 written
+  article alifs (955 wasl-marked, 328 prefixed bare), 22 suppressed-alif
+  prefix forms, and the two interrogative tokens; the reviewed long bases
+  cover 214 tokens.
+- The one adjacent-ayah boundary written with a full qata after a sakin host
+  is `كِتَٰبِيَهْۖ إِنِّے`, matching the authored tahqiq-default exclusion.
+
+The research file's 1,550 within-ayah and 180 adjacent-ayah subtotals in
+`docs/warsh/research/v2/naql.md` are not reproducible from the supplied
+families under any principled cut; the mechanical totals above supersede
+them for conformance. Two more intentional deltas against that file's
+tables: dad is not a qalqala letter, so waqf on `اِ۬لَارْضِ` ends
+`l a rˤ dˤ` with no release; and the received `عَاداٗ اَ۬لُّاول۪ىٰ` junction
+stays outside both the article family and the tanwin repair register until
+its idgham-with-naql face is implemented.
 
 ## Verse mode
 

--- a/docs/warsh/research/v2/naql.md
+++ b/docs/warsh/research/v2/naql.md
@@ -40,6 +40,14 @@ carrier is excluded because it is not a sakin sahih or leen host. A medial
 sakin within an ordinary word is excluded; `ردءا` below is the single
 authored lexical exception.
 
+This vertical implements the ordinary short-vowel family only. An initial
+hamza followed by a badal carrier is deferred to
+[`madd-badal.md`](madd-badal.md): naql transfers the short haraka, while the
+carrier separately owns the resulting length. Treating the whole long
+nucleus as naql would collapse `badal mughayyar bin-naql` into the wrong
+rule. The selected source has 227 deferred initial forms: 177 A, 47 U, and
+3 I.
+
 ## Corpus size and data ownership
 
 The selected corpus has 1,550 eligible within-ayah cross-word boundaries.

--- a/quranic_phonemizer/analysis/cells/projection.py
+++ b/quranic_phonemizer/analysis/cells/projection.py
@@ -319,9 +319,16 @@ def _place_rules(words: tuple[CellWord, ...], facts: AnalysisFacts,
         if isinstance(edge, Merged):
             targets = _column_targets(words, edge.sound, presenters=True)
         elif isinstance(edge, Silenced):
+            short_naql_vowel = (
+                rule == Rule.NAQL.value
+                and edge.aspect is Aspect.VOWEL
+                and not facts.slots[
+                    facts.slot_index[edge.slots[0]]
+                ].nucleus.sounds_long
+            )
             targets = (
                 []
-                if rule == Rule.NAQL.value and edge.aspect is Aspect.VOWEL
+                if short_naql_vowel
                 else _silenced_targets(columns, edge, slot_of_unit)
             )
         elif isinstance(edge, (Hosted, Insertion)):

--- a/quranic_phonemizer/analysis/cells/projection.py
+++ b/quranic_phonemizer/analysis/cells/projection.py
@@ -319,7 +319,11 @@ def _place_rules(words: tuple[CellWord, ...], facts: AnalysisFacts,
         if isinstance(edge, Merged):
             targets = _column_targets(words, edge.sound, presenters=True)
         elif isinstance(edge, Silenced):
-            targets = _silenced_targets(columns, edge, slot_of_unit)
+            targets = (
+                []
+                if rule == Rule.NAQL.value and edge.aspect is Aspect.VOWEL
+                else _silenced_targets(columns, edge, slot_of_unit)
+            )
         elif isinstance(edge, (Hosted, Insertion)):
             targets = _column_targets(words, edge.sound)
         else:

--- a/quranic_phonemizer/analysis/cells/projection.py
+++ b/quranic_phonemizer/analysis/cells/projection.py
@@ -322,15 +322,9 @@ def _place_rules(words: tuple[CellWord, ...], facts: AnalysisFacts,
             short_naql_vowel = (
                 rule == Rule.NAQL.value
                 and edge.aspect is Aspect.VOWEL
-                and not facts.slots[
-                    facts.slot_index[edge.slots[0]]
-                ].nucleus.sounds_long
+                and not facts.slots[facts.slot_index[edge.slots[0]]].nucleus.sounds_long
             )
-            targets = (
-                []
-                if short_naql_vowel
-                else _silenced_targets(columns, edge, slot_of_unit)
-            )
+            targets = [] if short_naql_vowel else _silenced_targets(columns, edge, slot_of_unit)
         elif isinstance(edge, (Hosted, Insertion)):
             targets = _column_targets(words, edge.sound)
         else:

--- a/quranic_phonemizer/analysis/cells/projection.py
+++ b/quranic_phonemizer/analysis/cells/projection.py
@@ -319,12 +319,9 @@ def _place_rules(words: tuple[CellWord, ...], facts: AnalysisFacts,
         if isinstance(edge, Merged):
             targets = _column_targets(words, edge.sound, presenters=True)
         elif isinstance(edge, Silenced):
-            short_naql_vowel = (
-                rule == Rule.NAQL.value
-                and edge.aspect is Aspect.VOWEL
-                and not facts.slots[facts.slot_index[edge.slots[0]]].nucleus.sounds_long
-            )
-            targets = [] if short_naql_vowel else _silenced_targets(columns, edge, slot_of_unit)
+            targets = [] if (
+                rule == Rule.NAQL.value and edge.aspect is Aspect.VOWEL
+            ) else _silenced_targets(columns, edge, slot_of_unit)
         elif isinstance(edge, (Hosted, Insertion)):
             targets = _column_targets(words, edge.sound)
         else:

--- a/quranic_phonemizer/analysis/source_ownership.py
+++ b/quranic_phonemizer/analysis/source_ownership.py
@@ -146,8 +146,14 @@ def _silenced_units(facts, tok) -> dict[int, int]:
         if edge.aspect is Aspect.VOWEL:
             if rule is Rule.NAQL:
                 carrier = tok.roles.carrier.get(edge.slots[0])
-                if carrier is not None and carrier != unit:
+                if carrier is not None:
                     out.setdefault(carrier, edge.by)
+                elif facts.slots[
+                    facts.slot_index[edge.slots[0]]
+                ].nucleus.sounds_long:
+                    vowel = tok.roles.vowel.get(edge.slots[0])
+                    if vowel is not None:
+                        out.setdefault(vowel, edge.by)
                 continue
             unit = tok.roles.vowel.get(edge.slots[0], unit)
             if rule is Rule.WAQF_SILAH_DROP:

--- a/quranic_phonemizer/analysis/source_ownership.py
+++ b/quranic_phonemizer/analysis/source_ownership.py
@@ -141,12 +141,16 @@ def _silenced_units(facts, tok) -> dict[int, int]:
     for edge in facts.silences:
         if edge.by is None:
             continue
+        rule = facts.occurrences[edge.by].rule
         unit = tok.roles.letter.get(edge.slots[0])
         if edge.aspect is Aspect.VOWEL:
+            if rule is Rule.NAQL:
+                carrier = tok.roles.carrier.get(edge.slots[0])
+                if carrier is not None and carrier != unit:
+                    out.setdefault(carrier, edge.by)
+                continue
             unit = tok.roles.vowel.get(edge.slots[0], unit)
-            if facts.occurrences[edge.by].rule in (
-                Rule.WAQF_SILAH_DROP, Rule.NAQL,
-            ):
+            if rule is Rule.WAQF_SILAH_DROP:
                 carrier = tok.roles.carrier.get(edge.slots[0])
                 if carrier is not None:
                     out.setdefault(carrier, edge.by)

--- a/quranic_phonemizer/analysis/source_ownership.py
+++ b/quranic_phonemizer/analysis/source_ownership.py
@@ -145,15 +145,6 @@ def _silenced_units(facts, tok) -> dict[int, int]:
         unit = tok.roles.letter.get(edge.slots[0])
         if edge.aspect is Aspect.VOWEL:
             if rule is Rule.NAQL:
-                carrier = tok.roles.carrier.get(edge.slots[0])
-                if carrier is not None:
-                    out.setdefault(carrier, edge.by)
-                elif facts.slots[
-                    facts.slot_index[edge.slots[0]]
-                ].nucleus.sounds_long:
-                    vowel = tok.roles.vowel.get(edge.slots[0])
-                    if vowel is not None:
-                        out.setdefault(vowel, edge.by)
                 continue
             unit = tok.roles.vowel.get(edge.slots[0], unit)
             if rule is Rule.WAQF_SILAH_DROP:

--- a/quranic_phonemizer/analysis/source_ownership.py
+++ b/quranic_phonemizer/analysis/source_ownership.py
@@ -144,7 +144,9 @@ def _silenced_units(facts, tok) -> dict[int, int]:
         unit = tok.roles.letter.get(edge.slots[0])
         if edge.aspect is Aspect.VOWEL:
             unit = tok.roles.vowel.get(edge.slots[0], unit)
-            if facts.occurrences[edge.by].rule is Rule.WAQF_SILAH_DROP:
+            if facts.occurrences[edge.by].rule in (
+                Rule.WAQF_SILAH_DROP, Rule.NAQL,
+            ):
                 carrier = tok.roles.carrier.get(edge.slots[0])
                 if carrier is not None:
                     out.setdefault(carrier, edge.by)

--- a/quranic_phonemizer/data/riwayat/warsh/ledger.yaml
+++ b/quranic_phonemizer/data/riwayat/warsh/ledger.yaml
@@ -1,0 +1,12 @@
+# Authored Warsh canonical facts the selected script cannot carry alone.
+#
+# Values are the closed canonical vocabulary only; see canon/ledger.py.
+schema_version: 1
+riwayah: warsh
+
+supplies:
+  # 28:34 `رِداٗ` - the one within-word lexical naql: the hamza of ردء is
+  # deleted in every state and its fatha stays on the dal. The written form
+  # is already transformed; this names the latent qata responsibility.
+  - {slot: "28:34:9#1", skeleton: "ردن", fact: TAJWEED_MARK, value: NAQL,
+     citation: "Warsh via al-Azraq; Al-Wafi on the fixed naql of رِدْءًا"}

--- a/quranic_phonemizer/engine/run.py
+++ b/quranic_phonemizer/engine/run.py
@@ -66,6 +66,7 @@ _CLASSIFIES_ASPECT: dict[Rule, Aspect] = {
     Rule.MADD_ARID_LISSUKUN: Aspect.VOWEL,
     Rule.MADD_TABII: Aspect.VOWEL,
     Rule.IBDAL_HAMZA: Aspect.VOWEL,
+    Rule.NAQL: Aspect.VOWEL,
     #: The waw or yaa this rule names has no vowel; it classifies the consonant.
     Rule.MADD_LEEN: Aspect.CONSONANT,
 }

--- a/quranic_phonemizer/model/canon.py
+++ b/quranic_phonemizer/model/canon.py
@@ -113,6 +113,10 @@ class Annotation(StrEnum):
     JOINED_PARTICLE = "joined_particle"
     """This slot ends a particle the rasm joined to the word after it, so
     what follows opens a word: `هَـٰٓؤُلَآءِ` is `ها` + `أولاء`."""
+    NAQL = "naql"
+    """This slot's vowel was carried from a qata hamza deleted after it, and
+    the deletion holds in every boundary state: the article family and the
+    lexical `ردءا`."""
 
 
 class VowelForm(StrEnum):
@@ -328,6 +332,7 @@ class Rule(StrEnum):
     MADD_SILAH = "madd_silah"
 
     IBDAL_HAMZA = "ibdal_hamza"
+    NAQL = "naql"
     HAMZA_WASL_SILENT = "hamza_wasl_silent"
     HAMZA_WASL_FATHA = "hamza_wasl_fatha"
     HAMZA_WASL_KASRA = "hamza_wasl_kasra"
@@ -370,6 +375,7 @@ ILTIQA_RULES: frozenset[Rule] = frozenset(
 #: a merger's two edges belong to one occurrence.
 CLASSIFICATION_ONLY: frozenset[Rule] = frozenset(
     {
+        Rule.NAQL,
         Rule.TARQEEQ,
         Rule.GHUNNAH_MUSHADDADAH,
         Rule.IDGHAM_MUTAJANISAYN_NAQIS,

--- a/quranic_phonemizer/model/definitions.py
+++ b/quranic_phonemizer/model/definitions.py
@@ -141,6 +141,10 @@ RULE_DEFINITIONS: dict[Rule, tuple[str, str, str]] = {
         "Ibdal Hamza", "إبدال الهمزة",
         "Started on, a prosthetic hamza lengthens its vowel over the quiescent hamza after it.",
     ),
+    Rule.NAQL: (
+        "Naql", "نقل",
+        "A qata hamza's vowel moves to the quiescent letter before it and the hamza itself is not sounded.",
+    ),
     Rule.HAMZA_WASL_SILENT: (
         "Hamza Wasl Silent", "حذف همزة الوصل",
         "A prosthetic hamza is not sounded when the word before it is joined to it.",

--- a/quranic_phonemizer/riwayat/warsh/naql_script.py
+++ b/quranic_phonemizer/riwayat/warsh/naql_script.py
@@ -1,0 +1,185 @@
+"""Reviewed naql spellings in the selected King Fahd Warsh script.
+
+The source writes the transformed joined form; projection restores the
+canonical sakin host and latent qata, and annotates the article family."""
+from __future__ import annotations
+
+from ...model.canon import Annotation, CanonLetter, Nucleus, Onset, Quality
+from ...model.inscription import GraphemeClass, SlotFact
+from ...orthography.inventory import LetterEntry, MarkEntry
+
+_HARAKA_QUALITY = {"َ": Quality.A, "ُ": Quality.U, "ِ": Quality.I}
+_HARAKA_ROLE = {"َ": "fatha", "ُ": "damma", "ِ": "kasra"}
+_WASL_MARKS = frozenset("۪۬۟")
+
+#: Scalars that carry no letter identity when reading a base skeleton.
+_NON_SKELETON = frozenset('ًٌٍَُِّْٰٖ۪ٗٞٓ۬۟ـۥۦٕۧۢٔ')
+
+#: The eased `جَآءَ ا۟لَ` tokens: their onset belongs to the hamza-meetings
+#: chapter, not to naql, although they share the bare-alif spelling.
+_EASED_AAL = "ا۟لَ"
+
+#: A word may not end on these when locating the written moved vowel: stop
+#: signs, the plural alif, and its silencing sukun.
+_HOST_TRAIL = frozenset("اْۖ۩")
+
+#: Proclitic letters (with their harakas) that may precede a bare-alif
+#: article in this source.
+_PROCLITICS = {"و": "َ", "ف": "َ", "ب": "ِ", "ك": "َ"}
+
+#: Article bases whose deleted qata carried the long badal A, so the written
+#: `لَا`/`لَٰ` reads long. Everything else in the family reads the short
+#: transferred vowel. Reviewed against the full selected corpus.
+_LONG_BASES = frozenset({
+    "ثمين", "خر", "خرة", "خرين", "زفة", "صال", "فاق", "فلين",
+    "كلين", "لهة", "مرون", "منين", "ن", "ية", "يت",
+})
+
+#: The one verse-final host written with its moved vowel: source `وَانْحَرِ`
+#: before the latent `اِنَّ` opening the next verse.
+_VERSE_FINAL_HOSTS = {"وَانْحَرِ": Quality.I}
+
+
+def latent_qata_quality(text: str) -> Quality | None:
+    """The transferred vowel a word-initial latent qata spells, or None."""
+    if len(text) < 2 or text[0] != "ا":
+        return None
+    if text[1] in _HARAKA_QUALITY and (len(text) < 3 or text[2] not in _WASL_MARKS):
+        if len(text) >= 5 and text[2] == "ل" and text[4] == "ٓ":
+            return None  # a vocalized compact opening spells letter names
+        return _HARAKA_QUALITY[text[1]]
+    if text[1] == "۟" and (len(text) < 3 or text[2] not in _HARAKA_QUALITY):
+        return None if text.startswith(_EASED_AAL) else Quality.U
+    if text[1] == "ٰ":
+        return Quality.A  # the badal family: a latent qata with its long A
+    return None
+
+
+def project_latent_qata(text: str, entries: list) -> None:
+    """A word-initial bare alif family is the latent qata hamza itself."""
+    if latent_qata_quality(text) is None:
+        return
+    entries[0] = LetterEntry(CanonLetter.HAMZA)
+    if text[1] == "۟":
+        # The stroke spells the qata's damm here, not a wasl start quality.
+        entries[1] = MarkEntry(
+            role="damma",
+            cls=GraphemeClass.HARAKA,
+            fact=SlotFact.VOWEL_QUALITY,
+            value=Nucleus.short(Quality.U),
+        )
+
+
+def demote_moved_haraka(text: str, entries: list, quality: Quality) -> None:
+    """The host's written final haraka is the naql witness, not its own
+    canonical vowel: the underlying host stays sakin."""
+    index = len(text) - 1
+    while index > 0 and text[index] in _HOST_TRAIL:
+        index -= 1
+    if index <= 0 or _HARAKA_QUALITY.get(text[index]) is not quality:
+        return
+    entries[index] = MarkEntry(
+        role="naql_witness",
+        cls=GraphemeClass.HARAKA,
+        decorates="host",
+        attests=True,
+    )
+
+
+def project_verse_final_host(text: str, entries: list) -> None:
+    quality = _VERSE_FINAL_HOSTS.get(text)
+    if quality is not None:
+        demote_moved_haraka(text, entries, quality)
+
+
+def _skeleton(text: str) -> str:
+    return "".join(char for char in text if char not in _NON_SKELETON)
+
+
+def _article_lam(text: str) -> tuple[int, int | None] | None:
+    """The naql'd article lam index and the bare wasl alif to project."""
+    if (
+        len(text) >= 4
+        and text[0] == "ا"
+        and text[1] in _HARAKA_QUALITY
+        and text[2] == "۬"
+        and text[3] == "ل"
+    ):
+        return 3, None
+    prefixed = _prefixed_lam(text)
+    if prefixed is not None:
+        return prefixed
+    lil = _lil_lam(text)
+    if lil is not None:
+        return lil, None
+    if text.startswith("ءَال") and _skeleton(text[6:]) == "ن":
+        return 3, None  # the interrogative `ءَالَٰنَ`; the prefix stays qata
+    return None
+
+
+def _prefixed_lam(text: str) -> tuple[int, int] | None:
+    index = 0
+    while (
+        index + 1 < len(text)
+        and text[index] in _PROCLITICS
+        and text[index + 1] == _PROCLITICS[text[index]]
+    ):
+        index += 2
+    if index and index + 1 < len(text) and text[index] == "ا" and text[index + 1] == "ل":
+        return index + 1, index
+    return None
+
+
+def _lil_lam(text: str) -> int | None:
+    index = 2 if text.startswith("وَ") else 0
+    if index >= len(text) or text[index] != "ل":
+        return None
+    index += 1
+    voweled = False
+    while index < len(text) and text[index] in "َِّ":
+        voweled = voweled or text[index] in _HARAKA_QUALITY
+        index += 1
+    if voweled and index < len(text) and text[index] == "ل":
+        return index
+    return None
+
+
+def project_article_naql(text: str, entries: list) -> None:
+    """A voweled article lam followed by the deleted qata's rasm."""
+    found = _article_lam(text)
+    if found is None:
+        return
+    lam, wasl_alif = found
+    haraka = lam + 1
+    carrier = lam + 2
+    if haraka >= len(text) or text[haraka] not in _HARAKA_QUALITY:
+        return
+    if carrier >= len(text) or text[carrier] not in "اٰ":
+        return
+    long_base = text[carrier] == "ٰ" or _skeleton(text[carrier + 1:]) in _LONG_BASES
+    entries[carrier] = MarkEntry(
+        role="naql_qata_rasm",
+        cls=GraphemeClass.ANNOTATION,
+        fact=SlotFact.TAJWEED_MARK,
+        value=Annotation.NAQL,
+    )
+    if long_base:
+        entries[haraka] = MarkEntry(
+            role=_HARAKA_ROLE[text[haraka]],
+            cls=GraphemeClass.HARAKA,
+            fact=SlotFact.VOWEL_QUALITY,
+            value=Nucleus.long(Quality.A),
+        )
+    if wasl_alif is not None:
+        entries[wasl_alif] = LetterEntry(
+            CanonLetter.HAMZA, onset=Onset.WASL, seat=True
+        )
+
+
+__all__ = [
+    "demote_moved_haraka",
+    "latent_qata_quality",
+    "project_article_naql",
+    "project_latent_qata",
+    "project_verse_final_host",
+]

--- a/quranic_phonemizer/riwayat/warsh/naql_script.py
+++ b/quranic_phonemizer/riwayat/warsh/naql_script.py
@@ -44,14 +44,31 @@ def latent_qata_quality(text: str) -> Quality | None:
     """The transferred vowel a word-initial latent qata spells, or None."""
     if len(text) < 2 or text[0] != "ا":
         return None
+    if latent_qata_badal_quality(text) is not None:
+        return None
     if text[1] in _HARAKA_QUALITY and (len(text) < 3 or text[2] not in _WASL_MARKS):
         if len(text) >= 5 and text[2] == "ل" and text[4] == "ٓ":
             return None  # a vocalized compact opening spells letter names
         return _HARAKA_QUALITY[text[1]]
     if text[1] == "۟" and (len(text) < 3 or text[2] not in _HARAKA_QUALITY):
         return None if text.startswith(_EASED_AAL) else Quality.U
+    return None
+
+
+def latent_qata_badal_quality(text: str) -> Quality | None:
+    """The initial long badal family deferred from ordinary naql."""
+    if len(text) < 2 or text[0] != "ا":
+        return None
     if text[1] == "ٰ":
-        return Quality.A  # the badal family: a latent qata with its long A
+        return Quality.A
+    if len(text) < 3:
+        return None
+    if text[1] in "ُ۟" and text[2] == "و":
+        return Quality.U
+    if text[1] == "ِ" and text[2] in "يے" and (
+        len(text) < 4 or text[3] != "ّ"
+    ):
+        return Quality.I
     return None
 
 
@@ -178,6 +195,7 @@ def project_article_naql(text: str, entries: list) -> None:
 
 __all__ = [
     "demote_moved_haraka",
+    "latent_qata_badal_quality",
     "latent_qata_quality",
     "project_article_naql",
     "project_latent_qata",

--- a/quranic_phonemizer/riwayat/warsh/resources.py
+++ b/quranic_phonemizer/riwayat/warsh/resources.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from ...canon import derive
 from ...canon.ledger import EMPTY as EMPTY_LEDGER
-from ...canon.ledger import Ledger
+from ...canon.ledger import Ledger, load_ledger
 from ...canon.lexicon import Lexicon, load_affixes, load_lexicon
 from ...canon.passes import LEXEME_PASSES
 from ...canon.spell import Muqattaat, load_muqattaat, spell_muqattaat
@@ -21,7 +21,7 @@ from ...orthography.inventory import Inventory, load_inventory
 from ..khilaf import EMPTY as EMPTY_KHILAF
 from ..khilaf import Khilaf
 from ..tables import RuleTables, load_rule_tables
-from .sequence import entries_for
+from .sequence import entries_for_words
 
 RIWAYAH = Riwayah.WARSH
 SCRIPTS = (Script.UTHMANI,)
@@ -42,11 +42,16 @@ class Adapter:
     def read(
         self, verse: VerseRef, words: tuple[tuple[Location, str], ...]
     ) -> Reading:
+        prepared = iter(
+            entries_for_words(
+                self.inventory, tuple(text for _, text in words)
+            )
+        )
         return read_verse(
             self.inventory,
             verse,
             words,
-            entries_for=lambda text: entries_for(self.inventory, text),
+            entries_for=lambda text: next(prepared),
             sources_for=self.corpus.sources_for,
         )
 
@@ -83,7 +88,8 @@ def adapters_for(riwayah: Riwayah) -> dict[Script, Adapter]:
 
 @lru_cache(maxsize=None)
 def ledger() -> Ledger:
-    return EMPTY_LEDGER
+    path = DATA / "ledger.yaml"
+    return load_ledger(path, riwayah=RIWAYAH) if path.exists() else EMPTY_LEDGER
 
 
 @lru_cache(maxsize=None)

--- a/quranic_phonemizer/riwayat/warsh/rules.py
+++ b/quranic_phonemizer/riwayat/warsh/rules.py
@@ -25,9 +25,11 @@ from ...rules.madd import (
 )
 from ...rules.pausal_glide import PausalGlide
 from ...rules.meem_sakinah import GhunnahMushaddadah, MeemSakinah
+from ...rules.naql import CarriedNaql, Naql
 from ...rules.noon_sakinah import IkhfaaWeight, NoonSakinah
 from ...rules.qalqala import Qalqala
 from ...rules.tafkheem import Emphasis, Weight
+from ...model.address import Location
 from ...model.canon import Quality
 from ...rules.wasl import (
     SoftenedHamza,
@@ -41,11 +43,32 @@ from .resources import khilaf, lexicon, rule_tables
 #: original damm; the shared kasra and fatha defaults stand elsewhere.
 _DAMM_START_REPAIR = {Quality.U: Quality.U}
 
+#: The `كتابيه إني` boundary reads tahqiq by default: haa stays sakin and
+#: the qata is fully realized, so the general transfer must not claim it.
+_NAQL_TAHQIQ = frozenset({Location(69, 20, 1)})
+
 
 def _article(tables) -> ArticleShape:
     return ArticleShape(
         prefixes=tables.proclitics,
         is_form_eight_lam=lexicon().is_form_eight_lam,
+    )
+
+
+def _boundary() -> tuple:
+    return (
+        Naql(excluded=_NAQL_TAHQIQ),
+        CarriedNaql(),
+        WaslHamza(),
+        SoftenedHamza(),
+        SpelledBeforeWasl(repairs=_DAMM_START_REPAIR),
+        TanweenBeforeWasl(repairs=_DAMM_START_REPAIR),
+        TanweenDrop(),
+        TanweenIwad(),
+        WaqfHarakaDrop(yaa=khilaf().yaa),
+        WaqfSilahDrop(),
+        DroppedGlide(yaa=khilaf().yaa),
+        TaaMarbutaAtWaqf(),
     )
 
 
@@ -55,18 +78,7 @@ def _build() -> RuleSet:
     article = _article(tables)
     return RuleSet(
         {
-            Phase.BOUNDARY: (
-                WaslHamza(),
-                SoftenedHamza(),
-                SpelledBeforeWasl(repairs=_DAMM_START_REPAIR),
-                TanweenBeforeWasl(repairs=_DAMM_START_REPAIR),
-                TanweenDrop(),
-                TanweenIwad(),
-                WaqfHarakaDrop(yaa=khilaf().yaa),
-                WaqfSilahDrop(),
-                DroppedGlide(yaa=khilaf().yaa),
-                TaaMarbutaAtWaqf(),
-            ),
+            Phase.BOUNDARY: _boundary(),
             Phase.MERGE: (
                 NoonSakinah(followers=tables.followers_of_noon),
                 MeemSakinah(followers=tables.followers_of_meem),

--- a/quranic_phonemizer/riwayat/warsh/sequence.py
+++ b/quranic_phonemizer/riwayat/warsh/sequence.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import replace
 
 from ...model.canon import CanonLetter, Nucleus, Onset, Quality
 from ...model.inscription import GraphemeClass, SlotFact
 from ...orthography.inventory import Inventory, LetterEntry, MarkEntry
+from . import naql_script
 
 
 _HARAKA_TO_TANWIN = {
@@ -191,19 +193,38 @@ def _project_composite_tanwin(text, entries) -> None:
                 )
 
 
-def entries_for(inventory: Inventory, text: str):
-    """Return one classification per scalar without changing source text."""
+def _entries(inventory: Inventory, text: str) -> list:
     entries = [inventory.classify(char) for char in text]
     _release_combining_hamza_seats(inventory, text, entries)
     wasl = _wasl_sequence(text, entries)
+    naql_script.project_latent_qata(text, entries)
+    naql_script.project_article_naql(text, entries)
+    naql_script.project_verse_final_host(text, entries)
     _project_marked_fatha(text, entries, wasl=wasl)
     _attach_reversed_fathatan(text, entries)
     _project_plural_alif_silence(text, entries)
     _project_orthographic_silence(text, entries)
     _release_dagger_hamza_seats(text, entries)
     _project_composite_tanwin(text, entries)
+    return entries
 
-    return tuple(entries)
+
+def entries_for(inventory: Inventory, text: str):
+    """Return one classification per scalar without changing source text."""
+    return tuple(_entries(inventory, text))
 
 
-__all__ = ["entries_for"]
+def entries_for_words(inventory: Inventory, texts: Sequence[str]):
+    """Per-word classifications for one verse, with cross-word context: a
+    host's written moved haraka before a latent qata is a naql witness."""
+    prepared = [_entries(inventory, text) for text in texts]
+    for index in range(len(texts) - 1):
+        quality = naql_script.latent_qata_quality(texts[index + 1])
+        if quality is not None:
+            naql_script.demote_moved_haraka(
+                texts[index], prepared[index], quality
+            )
+    return tuple(tuple(entries) for entries in prepared)
+
+
+__all__ = ["entries_for", "entries_for_words"]

--- a/quranic_phonemizer/rules/madd.py
+++ b/quranic_phonemizer/rules/madd.py
@@ -122,6 +122,8 @@ def _madd_of(
     slot, word = near.slot(at), near.word_of(at)
     if slot is None or word is None or not slot.nucleus.sounds_long:
         return None
+    if plan.merged_away(at, Aspect.VOWEL):
+        return None  # a vowel a boundary rule deleted has no length left
     slots = near.score.words[word].slots
     final = bool(slots) and slots[-1].id == at
 

--- a/quranic_phonemizer/rules/naql.py
+++ b/quranic_phonemizer/rules/naql.py
@@ -1,0 +1,85 @@
+"""Naql: a qata hamza's vowel moves back onto the quiescent host before it.
+
+Joined-only transfer reads the plan; the carried shape holds in every state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..engine.neighbourhood import Neighbourhood
+from ..engine.plan import Phase, Plan, Realize, Silence, Verdict, mint
+from ..model.address import BoundaryPlan, Junction, Location, SlotId
+from ..model.canon import Annotation, CanonLetter, Onset, Rule
+from ..model.performance import Aspect, Occurrence, Vowel
+from .ownership import is_quiescent
+
+
+@dataclass(frozen=True, slots=True)
+class Naql:
+    """Joined speech only: the host takes exactly the qata's vowel and the
+    qata onset is silent. The subject order is the qata, then its host."""
+
+    excluded: frozenset[Location] = frozenset()
+    """Authored boundaries the riwayah reads with tahqiq instead; the qata
+    word's location keys each one."""
+
+    rule: Rule = Rule.NAQL
+    phase: Phase = Phase.BOUNDARY
+    triggers: frozenset = frozenset({CanonLetter.HAMZA})
+    emits: frozenset = frozenset({Rule.NAQL})
+
+    def look(
+        self, near: Neighbourhood, plan: Plan, at: SlotId,
+        boundaries: BoundaryPlan,
+    ) -> Verdict | None:
+        del plan
+        slot, word = near.slot(at), near.word_of(at)
+        if slot is None or not word:
+            return None
+        if slot.letter is not CanonLetter.HAMZA or slot.onset is not Onset.PLAIN:
+            return None
+        if slot.nucleus.is_silent or not near.first_of_word(at):
+            return None
+        if boundaries.after(word - 1) is not Junction.JOIN:
+            return None
+        host = near.before(at)
+        # A spelled opening ends as it would at a pause, so it hosts nothing.
+        if host is None or not is_quiescent(host) or host.spelled:
+            return None
+        if near.score.words[word].location in self.excluded:
+            return None
+        vowel = Vowel(slot.nucleus.quality, long=slot.nucleus.sounds_long)
+        return Verdict(
+            Occurrence(
+                mint(Rule.NAQL, at), Rule.NAQL, (at, host.id),
+                boundary=word - 1,
+            ),
+            (
+                Realize(host.id, Aspect.VOWEL, vowel),
+                Silence(at, Aspect.CONSONANT),
+                Silence(at, Aspect.VOWEL),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CarriedNaql:
+    """A host whose canonical vowel already is the transferred one: the
+    article family and authored lexical sites. The qata never returns, so
+    the occurrence names the host and its carried vowel in every state."""
+
+    rule: Rule = Rule.NAQL
+    phase: Phase = Phase.BOUNDARY
+    triggers: frozenset = frozenset({Annotation.NAQL})
+    emits: frozenset = frozenset({Rule.NAQL})
+
+    def look(
+        self, near: Neighbourhood, plan: Plan, at: SlotId,
+        boundaries: BoundaryPlan,
+    ) -> Verdict | None:
+        del plan, boundaries
+        slot = near.slot(at)
+        if slot is None or Annotation.NAQL not in slot.annotations:
+            return None
+        # Effect-free: the carried vowel is already canonical, so the
+        # classification-only machinery names it without claiming the slot.
+        return Verdict(Occurrence(mint(Rule.NAQL, at), Rule.NAQL, (at,)), ())

--- a/quranic_phonemizer/rules/naql.py
+++ b/quranic_phonemizer/rules/naql.py
@@ -15,7 +15,7 @@ from .ownership import is_quiescent
 
 @dataclass(frozen=True, slots=True)
 class Naql:
-    """Joined speech only: the host takes exactly the qata's vowel and the
+    """Joined speech only: the host takes the qata's short vowel and the
     qata onset is silent. The subject order is the qata, then its host."""
 
     excluded: frozenset[Location] = frozenset()
@@ -37,7 +37,9 @@ class Naql:
             return None
         if slot.letter is not CanonLetter.HAMZA or slot.onset is not Onset.PLAIN:
             return None
-        if slot.nucleus.is_silent or not near.first_of_word(at):
+        if slot.nucleus.is_silent or slot.nucleus.sounds_long:
+            return None
+        if not near.first_of_word(at):
             return None
         if boundaries.after(word - 1) is not Junction.JOIN:
             return None
@@ -47,7 +49,7 @@ class Naql:
             return None
         if near.score.words[word].location in self.excluded:
             return None
-        vowel = Vowel(slot.nucleus.quality, long=slot.nucleus.sounds_long)
+        vowel = Vowel(slot.nucleus.quality)
         return Verdict(
             Occurrence(
                 mint(Rule.NAQL, at), Rule.NAQL, (at, host.id),

--- a/quranic_phonemizer/rules/qalqala.py
+++ b/quranic_phonemizer/rules/qalqala.py
@@ -45,8 +45,9 @@ class Qalqala:
             return None  # an assimilated closure is held, never released
 
         # The echo needs a real closure: either canonically silent, or
-        # silenced by a BOUNDARY rule. A long final vowel is neither.
-        canonically = slot.nucleus.is_silent
+        # silenced by a BOUNDARY rule. A long final vowel is neither, and
+        # neither is a sakin an earlier repair or transfer has voweled.
+        canonically = slot.nucleus.is_silent and not plan.voweled(at)
         silenced = plan.merged_away(at, Aspect.VOWEL)
         if not (canonically or silenced):
             return None

--- a/tests/adapter/test_warsh_script_projection.py
+++ b/tests/adapter/test_warsh_script_projection.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from quranic_phonemizer.model.address import Location, Script
-from quranic_phonemizer.model.canon import CanonLetter, Nucleus, Onset, Quality
+from quranic_phonemizer.model.canon import (
+    Annotation,
+    CanonLetter,
+    Nucleus,
+    Onset,
+    Quality,
+)
 from quranic_phonemizer.model.inscription import SlotFact
 from quranic_phonemizer.orthography.inventory import InventoryError
 from quranic_phonemizer.riwayat.warsh.resources import corpus, script_adapter
@@ -162,3 +168,104 @@ def test_yeh_barree_is_preserved_as_source_but_projects_to_yaa():
     assert reading.clusters[-1].letter is CanonLetter.YA
     assert barree.source.location == entry.sources[0].location
     assert barree.source.offset == entry.text.index("ے")
+
+
+def _reading_pair(first: tuple[int, int, int], second: tuple[int, int, int]):
+    one, two = Location(*first), Location(*second)
+    entries = (corpus().entries[one], corpus().entries[two])
+    return entries, script_adapter(Script.UTHMANI).read(
+        one.verse, ((one, entries[0].text), (two, entries[1].text))
+    )
+
+
+def test_a_word_initial_bare_alif_haraka_supplies_the_latent_qata():
+    entry, reading = _reading((23, 1, 2))  # اَفْلَحَ
+    first = reading.clusters[0]
+    quality = _evidence_at(reading, 1, SlotFact.VOWEL_QUALITY)
+
+    assert entry.text[:2] == "اَ"
+    assert first.letter is CanonLetter.HAMZA and first.onset is None
+    assert quality.value == Nucleus.short(Quality.A)
+
+
+def test_the_damm_stroke_after_a_bare_alif_is_the_qata_damm():
+    entry, reading = _reading((77, 12, 3))  # ا۟جِّلَتْ
+    first = reading.clusters[0]
+    quality = _evidence_at(reading, 1, SlotFact.VOWEL_QUALITY)
+
+    assert entry.text[1] == "۟"
+    assert first.letter is CanonLetter.HAMZA and first.onset is None
+    assert quality.value == Nucleus.short(Quality.U)
+
+
+def test_the_same_stroke_in_a_wasl_sequence_stays_the_start_quality():
+    entry, reading = _reading((7, 195, 21))  # اُ۟دْعُواْ
+    first = reading.clusters[0]
+    quality = _evidence_at(reading, 2, SlotFact.VOWEL_QUALITY)
+
+    assert entry.text[2] == "۟"
+    assert first.letter is CanonLetter.HAMZA and first.onset is Onset.WASL
+    assert quality.value == Nucleus.short(Quality.U)
+
+
+def test_the_eased_aal_spelling_is_not_claimed_by_the_latent_family():
+    entry, reading = _reading((15, 61, 3))  # جَآءَ ا۟لَ
+    assert entry.text.startswith("ا۟لَ")
+    assert not any(
+        row.offset == 1 and row.fact is SlotFact.VOWEL_QUALITY
+        for row in reading.evidence
+    )
+
+
+def test_the_moved_host_haraka_demotes_to_a_naql_witness():
+    (host, _), reading = _reading_pair((23, 1, 1), (23, 1, 2))  # قَدَ اَفْلَحَ
+    fatha = 3
+    decoration = next(row for row in reading.decorations if row.offset == fatha)
+
+    assert host.text[fatha] == "َ"
+    assert reading.clusters[decoration.cluster].letter is CanonLetter.DAL
+    assert not any(
+        row.offset == fatha and row.fact is SlotFact.VOWEL_QUALITY
+        for row in reading.evidence
+    )
+    assert any(row.offset == fatha for row in reading.attestations)
+
+
+def test_the_latent_qata_keeps_its_full_shape_for_restoration():
+    # The projection never bakes the joined outcome in: the qata's letter and
+    # vowel stay canonical, so ibtidaa and a stop before it restore the hamza.
+    _, reading = _reading_pair((23, 1, 1), (23, 1, 2))
+    qata = next(
+        cluster for cluster in reading.clusters if cluster.word == 1
+    )
+    assert qata.letter is CanonLetter.HAMZA
+    assert qata.mark("fatha") is not None
+
+
+def test_the_article_rasm_alif_supplies_the_carried_naql_annotation():
+    entry, reading = _reading((2, 11, 7))  # اِ۬لَارْضِ
+    alif = 5
+    annotation = _evidence_at(reading, alif, SlotFact.TAJWEED_MARK)
+
+    assert entry.text[alif] == "ا"
+    assert reading.clusters[annotation.cluster].letter is CanonLetter.LAM
+    assert annotation.value is Annotation.NAQL
+
+
+def test_a_long_article_base_supplies_its_length_on_the_lam():
+    entry, reading = _reading((2, 4, 10))  # وَبِالَاخِرَةِ
+    wasl = reading.clusters[2]
+    quality = _evidence_at(reading, 6, SlotFact.VOWEL_QUALITY)
+    annotation = _evidence_at(reading, 7, SlotFact.TAJWEED_MARK)
+
+    assert entry.text[4:8] == "الَا"
+    assert wasl.letter is CanonLetter.HAMZA and wasl.onset is Onset.WASL
+    assert quality.value == Nucleus.long(Quality.A)
+    assert annotation.value is Annotation.NAQL
+
+
+def test_an_ordinary_lam_alif_shape_is_not_an_article_naql():
+    entry, reading = _reading((20, 45, 1))  # قَالَا
+    assert not any(
+        row.fact is SlotFact.TAJWEED_MARK for row in reading.evidence
+    )

--- a/tests/adapter/test_warsh_script_projection.py
+++ b/tests/adapter/test_warsh_script_projection.py
@@ -16,6 +16,7 @@ from quranic_phonemizer.model.canon import (
 )
 from quranic_phonemizer.model.inscription import SlotFact
 from quranic_phonemizer.orthography.inventory import InventoryError
+from quranic_phonemizer.riwayat.warsh import naql_script
 from quranic_phonemizer.riwayat.warsh.resources import corpus, script_adapter
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -196,6 +197,18 @@ def test_the_damm_stroke_after_a_bare_alif_is_the_qata_damm():
     assert entry.text[1] == "۟"
     assert first.letter is CanonLetter.HAMZA and first.onset is None
     assert quality.value == Nucleus.short(Quality.U)
+
+
+@pytest.mark.parametrize(("ref", "quality"), (
+    ((5, 41, 24), Quality.A),
+    ((2, 161, 7), Quality.U),
+    ((6, 158, 23), Quality.I),
+    ((10, 53, 5), Quality.I),
+))
+def test_initial_badals_are_deferred_from_ordinary_naql(ref, quality):
+    entry, _ = _reading(ref)
+    assert naql_script.latent_qata_badal_quality(entry.text) is quality
+    assert naql_script.latent_qata_quality(entry.text) is None
 
 
 def test_the_same_stroke_in_a_wasl_sequence_stays_the_start_quality():

--- a/tests/analysis/test_result_equivalence.py
+++ b/tests/analysis/test_result_equivalence.py
@@ -141,10 +141,17 @@ def test_sounds_agree_in_order_token_word_and_rules(hafs, pen, alphabet, ref, kw
 
 
 def test_rule_definition_inventory_equals_tajweed_rules():
+    """Each riwayah publishes an ordered slice of the one inventory, and the
+    two slices together cover the whole of it."""
     native = [
         (d.id.value, d.name, d.arabic_name, d.summary) for d in rule_definitions()
     ]
-    assert native == list(legacy_tajweed_rules("hafs"))
+    published = set()
+    for riwayah in ("hafs", "warsh"):
+        rows = list(legacy_tajweed_rules(riwayah))
+        assert [row for row in native if row in set(rows)] == rows
+        published.update(rows)
+    assert [row for row in native if row in published] == native
 
 
 @pytest.mark.parametrize(("ref", "kwargs"), SITES)

--- a/tests/api/test_phonemizer.py
+++ b/tests/api/test_phonemizer.py
@@ -166,12 +166,16 @@ def test_every_glyph_names_a_word_or_carries_no_word_at_all():
 
 def test_module_functions_answer_without_an_instance():
     assert supported_riwayat() == ("hafs", "warsh")
-    rules = tajweed_rules("hafs")
-    identifiers = {row[0] for row in rules}
-    assert identifiers == (
+    hafs_rules = tajweed_rules("hafs")
+    warsh_rules = tajweed_rules("warsh")
+    everything = (
         {rule.value for rule in Rule} | {reason.value for reason in SilenceReason}
     )
-    for identifier, english, arabic, summary in rules:
+    hafs_ids = {row[0] for row in hafs_rules}
+    warsh_ids = {row[0] for row in warsh_rules}
+    assert hafs_ids | warsh_ids == everything
+    assert "naql" in warsh_ids - hafs_ids
+    for identifier, english, arabic, summary in (*hafs_rules, *warsh_rules):
         assert identifier and english and arabic
         assert summary.endswith(".") and len(summary.split()) >= 5
 

--- a/tests/conformance/test_rule_coverage.py
+++ b/tests/conformance/test_rule_coverage.py
@@ -59,7 +59,10 @@ SAMPLE = (
 #: produced by some classifier in the corpus; a member here needs a reason,
 #: and `test_the_deferred_list_does_not_rot` fails once the reason no longer
 #: holds.
-DEFERRED: set[Rule] = set()
+#:
+#: `naql` is Warsh-only: no Hafs classifier emits it, and
+#: `test_naql_is_warsh_bound_and_fires` asserts the Warsh side.
+DEFERRED: set[Rule] = {Rule.NAQL}
 
 
 def _fired(packed, hafs, surah, ayah):
@@ -95,6 +98,26 @@ def test_the_deferred_list_does_not_rot(packed, hafs):
         fired |= _fired(packed, hafs, surah, ayah)
     stale = sorted(rule.value for rule in DEFERRED & fired)
     assert not stale, f"listed as deferred but firing: {stale}"
+
+
+def test_naql_is_warsh_bound_and_fires():
+    """The one Warsh-only rule: absent from the Hafs catalogue, present in
+    the Warsh one, and actually produced by the Warsh ruleset."""
+    from quranic_phonemizer.api import recitation
+    from quranic_phonemizer.model.address import Script, VerseRef
+    from quranic_phonemizer.riwayat.warsh.rules import WARSH
+
+    assert Rule.NAQL in WARSH.emitted()
+    assert Rule.NAQL not in ruleset_for(Riwayah.HAFS).emitted()
+
+    package = recitation(Riwayah.WARSH)
+    verse = VerseRef(23, 1)
+    words = package.words(verse)
+    built = package.build(package.read(Script.UTHMANI, verse, words))
+    plan = all_join(len(words))
+    fired = {o.rule for o in perform(built.score, WARSH, plan).occurrences}
+    assert Rule.NAQL in fired
+    assert fired <= WARSH.emitted()
 
 
 @pytest.mark.parametrize("riwayah", list(Riwayah))

--- a/tests/conformance/test_warsh_registers.py
+++ b/tests/conformance/test_warsh_registers.py
@@ -322,10 +322,8 @@ def _naql_boundaries():
 
 
 def test_the_naql_latent_register_reconciles_with_canonical_hosts():
-    """Every supplied latent qata stands after an eligible host: the written
-    moved haraka, a tanwin, or (at one edge) a spelled opening. The research
-    doc's 1,550/180 subtotals are not reproducible from the supplied
-    families; see docs/conformance.md."""
+    """Every supplied latent qata stands after an eligible host: a written
+    moved haraka, a tanwin, or one spelled opening at a verse edge."""
     within, edge = _naql_boundaries()
     assert sum(within.values()) == 1868
     assert within == Counter({
@@ -384,8 +382,8 @@ def test_a_full_hamza_after_a_sakin_verse_end_is_only_kitabiyah():
 
 
 def test_the_article_naql_register_is_the_documented_1307():
-    """1,283 written article alifs, 22 suppressed-alif prefix forms, and the
-    two interrogative tokens; the reviewed long bases cover 214 tokens."""
+    """Written article alifs, suppressed-alif prefix forms, and the two
+    interrogative tokens close the register with the reviewed long bases."""
     counts: Counter = Counter()
     longs = 0
     for location, entry in warsh_corpus().entries.items():

--- a/tests/conformance/test_warsh_registers.py
+++ b/tests/conformance/test_warsh_registers.py
@@ -272,8 +272,6 @@ def _naql_family(text: str) -> str | None:
     quality = naql_script.latent_qata_quality(text)
     if quality is None:
         return None
-    if text[1] == "\u0670":
-        return "badal"
     if text[1] == "\u06df":
         return "damm_stroke"
     return f"written_{quality.name}"
@@ -325,29 +323,35 @@ def test_the_naql_latent_register_reconciles_with_canonical_hosts():
     """Every supplied latent qata stands after an eligible host: a written
     moved haraka, a tanwin, or one spelled opening at a verse edge."""
     within, edge = _naql_boundaries()
-    assert sum(within.values()) == 1868
+    assert sum(within.values()) == 1658
     assert within == Counter({
         ("written_A", "moved_haraka"): 752,
         ("written_A", "tanwin"): 365,
-        ("written_I", "moved_haraka"): 174,
-        ("written_I", "tanwin"): 299,
-        ("written_U", "moved_haraka"): 1,
+        ("written_I", "moved_haraka"): 173,
+        ("written_I", "tanwin"): 298,
         ("written_U", "tanwin"): 1,
-        ("damm_stroke", "moved_haraka"): 60,
-        ("damm_stroke", "tanwin"): 43,
-        ("badal", "moved_haraka"): 131,
-        ("badal", "tanwin"): 42,
+        ("damm_stroke", "moved_haraka"): 46,
+        ("damm_stroke", "tanwin"): 23,
     })
     joinable = {key: count for key, count in edge.items() if key[1] != "surah_start"}
-    assert sum(joinable.values()) == 325
+    assert sum(joinable.values()) == 308
     assert joinable == {
         ("written_A", "tanwin"): 112,
         ("written_A", "spelled"): 1,
-        ("written_I", "tanwin"): 193,
+        ("written_I", "tanwin"): 192,
         ("written_I", "moved_haraka"): 1,
-        ("damm_stroke", "tanwin"): 14,
-        ("badal", "tanwin"): 4,
+        ("damm_stroke", "tanwin"): 2,
     }
+
+
+def test_the_227_initial_badals_are_deferred_from_ordinary_naql():
+    deferred = Counter(
+        quality.name
+        for entry in warsh_corpus().entries.values()
+        if (quality := naql_script.latent_qata_badal_quality(entry.text))
+        is not None
+    )
+    assert deferred == Counter({"A": 177, "U": 47, "I": 3})
 
 
 def test_a_full_hamza_after_a_sakin_verse_end_is_only_kitabiyah():

--- a/tests/conformance/test_warsh_registers.py
+++ b/tests/conformance/test_warsh_registers.py
@@ -10,9 +10,10 @@ from pathlib import Path
 import pytest
 
 from quranic_phonemizer.api import recitation
-from quranic_phonemizer.model.address import Riwayah, Script, VerseRef
-from quranic_phonemizer.model.canon import Onset
+from quranic_phonemizer.model.address import Location, Riwayah, Script, VerseRef
+from quranic_phonemizer.model.canon import Onset, Quality
 from quranic_phonemizer.phonemize.legacy_views import phonemes_by_word
+from quranic_phonemizer.riwayat.warsh import naql_script
 from quranic_phonemizer.riwayat.warsh.resources import corpus as warsh_corpus
 from tests.support.boundary import plan_for
 
@@ -262,3 +263,160 @@ def test_the_tanwin_repair_register_is_generated_from_the_source():
         source_ref for _, source_ref, family in DAMM_REPAIRS if family == "tanwin"
     }
     assert {ref for ref, quality in sites.items() if quality == "U"} == register_tanwin
+
+
+# ------------------------------------------------------------------ naql
+#: Host kinds a supplied latent qata may stand after; anything else is an
+#: unreviewed boundary.
+def _naql_family(text: str) -> str | None:
+    quality = naql_script.latent_qata_quality(text)
+    if quality is None:
+        return None
+    if text[1] == "\u0670":
+        return "badal"
+    if text[1] == "\u06df":
+        return "damm_stroke"
+    return f"written_{quality.name}"
+
+
+def _naql_host_kind(text: str, quality: Quality) -> str:
+    text = "".join(char for char in text if char not in STOP_SIGNS)
+    index = len(text) - 1
+    while index > 0 and text[index] in "\u0627\u0652":
+        index -= 1
+    char = text[index]
+    if char in HARAKA:
+        moved = HARAKA[char] == ("A" if quality is Quality.A else quality.name)
+        return "moved_haraka" if moved else "mismatch"
+    if char in TANWIN:
+        return "tanwin"
+    if char == "\u0653":
+        return "spelled"
+    return "other"
+
+
+@lru_cache(maxsize=None)
+def _naql_boundaries():
+    by_verse: dict[tuple[int, int], dict[int, str]] = {}
+    for location, entry in warsh_corpus().entries.items():
+        by_verse.setdefault((location.surah, location.ayah), {})[
+            location.word
+        ] = entry.text
+    within: Counter = Counter()
+    edge: Counter = Counter()
+    for (surah, ayah), words in by_verse.items():
+        for word, text in words.items():
+            family = _naql_family(text)
+            if family is None:
+                continue
+            quality = naql_script.latent_qata_quality(text)
+            if word > 1:
+                within[(family, _naql_host_kind(words[word - 1], quality))] += 1
+            elif ayah > 1 and (surah, ayah - 1) in by_verse:
+                previous = by_verse[(surah, ayah - 1)]
+                host = previous[max(previous)]
+                edge[(family, _naql_host_kind(host, quality))] += 1
+            else:
+                edge[(family, "surah_start")] += 1
+    return within, edge
+
+
+def test_the_naql_latent_register_reconciles_with_canonical_hosts():
+    """Every supplied latent qata stands after an eligible host: the written
+    moved haraka, a tanwin, or (at one edge) a spelled opening. The research
+    doc's 1,550/180 subtotals are not reproducible from the supplied
+    families; see docs/conformance.md."""
+    within, edge = _naql_boundaries()
+    assert sum(within.values()) == 1868
+    assert within == Counter({
+        ("written_A", "moved_haraka"): 752,
+        ("written_A", "tanwin"): 365,
+        ("written_I", "moved_haraka"): 174,
+        ("written_I", "tanwin"): 299,
+        ("written_U", "moved_haraka"): 1,
+        ("written_U", "tanwin"): 1,
+        ("damm_stroke", "moved_haraka"): 60,
+        ("damm_stroke", "tanwin"): 43,
+        ("badal", "moved_haraka"): 131,
+        ("badal", "tanwin"): 42,
+    })
+    joinable = {key: count for key, count in edge.items() if key[1] != "surah_start"}
+    assert sum(joinable.values()) == 325
+    assert joinable == {
+        ("written_A", "tanwin"): 112,
+        ("written_A", "spelled"): 1,
+        ("written_I", "tanwin"): 193,
+        ("written_I", "moved_haraka"): 1,
+        ("damm_stroke", "tanwin"): 14,
+        ("badal", "tanwin"): 4,
+    }
+
+
+def test_a_full_hamza_after_a_sakin_verse_end_is_only_kitabiyah():
+    """The one adjacent-ayah boundary written with tahqiq: كتابيه إني."""
+    by_verse: dict[tuple[int, int], dict[int, str]] = {}
+    for location, entry in warsh_corpus().entries.items():
+        by_verse.setdefault((location.surah, location.ayah), {})[
+            location.word
+        ] = entry.text
+    tahqiq = set()
+    for (surah, ayah), words in by_verse.items():
+        first = words[1]
+        if ayah == 1 or first[0] not in "\u0621\u0623\u0625":
+            continue
+        previous = by_verse.get((surah, ayah - 1))
+        if previous is None:
+            continue
+        host = "".join(
+            char for char in previous[max(previous)] if char not in STOP_SIGNS
+        )
+        index = len(host) - 1
+        while index > 0 and host[index] in "\u0627\u0652":
+            index -= 1
+        # A sakin consonant ends bare once the plural alif and sukun are
+        # stripped; a madda or carrier there is a long vowel, not a host.
+        if host[index] not in HARAKA and host[index] not in TANWIN and (
+            host[index] not in "\u0653\u0670\u06e5\u06e6\u06d2"
+        ) and host.endswith("\u0652"):
+            tahqiq.add(Location(surah, ayah, 1))
+    assert tahqiq == {Location(69, 20, 1)}
+    assert warsh_corpus().entries[Location(69, 20, 1)].text.startswith("إ")
+
+
+def test_the_article_naql_register_is_the_documented_1307():
+    """1,283 written article alifs, 22 suppressed-alif prefix forms, and the
+    two interrogative tokens; the reviewed long bases cover 214 tokens."""
+    counts: Counter = Counter()
+    longs = 0
+    for location, entry in warsh_corpus().entries.items():
+        text = "".join(char for char in entry.text if char not in STOP_SIGNS)
+        found = naql_script._article_lam(text)
+        if found is None:
+            continue
+        lam, wasl_alif = found
+        if lam + 2 >= len(text) or text[lam + 1] not in HARAKA:
+            continue
+        if text[lam + 2] not in "\u0627\u0670":
+            continue
+        if text.startswith("\u0621"):
+            kind = "interrogative"
+        elif text[0] == "\u0644" or text.startswith("\u0648\u064e\u0644"):
+            kind = "suppressed_alif"
+        elif wasl_alif is None:
+            kind = "written_alif"
+        else:
+            kind = "written_alif_prefixed"
+        counts[kind] += 1
+        if text[lam + 2] == "\u0670" or naql_script._skeleton(
+            text[lam + 3:]
+        ) in naql_script._LONG_BASES:
+            longs += 1
+    assert counts == Counter({
+        "written_alif": 955,
+        "written_alif_prefixed": 328,
+        "suppressed_alif": 22,
+        "interrogative": 2,
+    })
+    assert counts["written_alif"] + counts["written_alif_prefixed"] == 1283
+    assert sum(counts.values()) == 1307
+    assert longs == 214

--- a/tests/hardcase/test_catalogue_coverage.py
+++ b/tests/hardcase/test_catalogue_coverage.py
@@ -11,7 +11,11 @@ from tests.hardcase.registry import FixtureRef, RULE_FIXTURES
 
 
 def _catalogued() -> set[str]:
-    return {rule[0] for rule in tajweed_rules("hafs")}
+    return {
+        rule[0]
+        for riwayah in ("hafs", "warsh")
+        for rule in tajweed_rules(riwayah)
+    }
 
 
 def test_every_catalogued_rule_has_a_fixture():

--- a/tests/phonemize/hamza/test_warsh_naql.py
+++ b/tests/phonemize/hamza/test_warsh_naql.py
@@ -1,0 +1,136 @@
+"""Warsh naql: the qata's vowel moves to the sakin host in joined speech,
+and the qata is restored at every other boundary. The article family and
+the lexical ridan never restore it."""
+from __future__ import annotations
+
+import pytest
+
+from tests.support import (
+    Case,
+    Expect,
+    R,
+    Site,
+    StateCase,
+    assert_case,
+    case_runs,
+    explicit,
+)
+
+CASES = (
+    # Warsh: قَدَ اَفْلَحَ
+    StateCase(id="qad-aflaha", site=Site(warsh=("23:1", (1, 2))), states={
+        "joined": Expect(
+            read=explicit(ibtidaa=1, wasl=2),
+            phonemes=("q aˤ d a", "f l a ħ a"),
+            char_rules={"ا": R("naql"), "@fatha[2]": R("naql")},
+            sound_rules={"a[1]": R("naql")},
+            absent_char_rules={"د": R("qalqala_sughra"), "ف": R("naql")},
+        ),
+        "stopped-before": Expect(
+            read=explicit(ibtidaa=1, waqf=(1, 2)),
+            phonemes=("q aˤ d Q", "ʔ a f l a ħ"),
+            sound_rules={"Q": R("qalqala_kubra")},
+            absent_char_rules={"د": R("naql"), "ا": R("naql")},
+            absent_sound_rules={"ʔ": R("naql")},
+        ),
+    }),
+    # Warsh: عَذَابٌ اَلِيمُۢ
+    Case(
+        id="tanwin-noon",
+        site=Site(warsh=("2:104", (11, 12))),
+        read=explicit(ibtidaa=11, waqf=12),
+        phonemes=("ʕ a ð a: b u n a", "l i: m"),
+        char_rules={"ا[2]": R("naql")},
+        sound_rules={"a[2]": R("naql")},
+        absent_sound_rules={"n": R("izhar")},
+    ),
+    # Warsh: يَوْمٍ ا۟جِّلَتْ
+    Case(
+        id="tanwin-damm",
+        site=Site(warsh=("77:12", (2, 3))),
+        read=explicit(ibtidaa=2, waqf=3),
+        phonemes=("j a w m i n u", "ʒʒ i l a t"),
+        char_rules={"ا": R("naql"), "@round_zero": R("naql")},
+        sound_rules={"u": R("naql")},
+    ),
+    # Warsh: بَغَتِ
+    Case(
+        id="feminine-taa",
+        site=Site(warsh=("49:9", (9,))),
+        read=explicit(ibtidaa=9, waqf=10),
+        phonemes="b a ɣ aˤ t i",
+        sound_rules={"i": R("naql")},
+        absent_sound_rules={"t": R("naql")},
+    ),
+    # Warsh: تَعَالَوَاْ اَتْلُ
+    Case(
+        id="leen-waw",
+        site=Site(warsh=("6:151", (2, 3))),
+        read=explicit(ibtidaa=2, wasl=3),
+        phonemes=("t a ʕ a: l a w a", "t l u"),
+        char_rules={"ا[3]": R("naql"), "@fatha[4]": R("naql")},
+        sound_rules={"a[3]": R("naql")},
+        absent_sound_rules={"w": R("naql")},
+    ),
+    # Warsh: اِ۬لَارْضِ
+    StateCase(id="article-alard", site=Site(warsh=("2:11", (7,))), states={
+        "joined": Expect(
+            read=explicit(ibtidaa=6, wasl=7),
+            phonemes="l a rˤ dˤ i",
+            char_rules={
+                "@fatha": R("naql"), "ا[2]": R("naql"),
+                "ا[1]": R("hamza_wasl_silent"),
+            },
+            sound_rules={"a": R("naql")},
+            absent_char_rules={"ر": R("naql")},
+        ),
+        "ibtidaa": Expect(
+            read=explicit(ibtidaa=7, wasl=7),
+            phonemes="ʔ a l a rˤ dˤ i",
+            char_rules={"ا[1]": R("hamza_wasl_fatha"), "ا[2]": R("naql")},
+            sound_rules={"ʔ": R("hamza_wasl_fatha"), "a[2]": R("naql")},
+        ),
+        "stopped": Expect(
+            read=explicit(ibtidaa=6, waqf=7),
+            phonemes="l a rˤ dˤ",
+            char_rules={"ا[2]": R("naql")},
+            sound_rules={"a": R("naql")},
+        ),
+    }),
+    # Warsh: رِداٗ يُصَدِّقْنِےٓۖ
+    Case(
+        id="ridan-joined",
+        site=Site(warsh=("28:34", (9, 10))),
+        read=explicit(ibtidaa=9, waqf=10),
+        phonemes=("r i d a", "j̃ u sˤ aˤ dd i q Q n i:"),
+        char_rules={"@fathatan": R("naql", "idgham_bi_ghunnah")},
+        sound_rules={
+            "a": R("naql"), "j̃": R("idgham_bi_ghunnah"),
+            "Q": R("qalqala_sughra"),
+        },
+    ),
+    # Warsh: رِداٗ
+    Case(
+        id="ridan-waqf",
+        site=Site(warsh=("28:34", (9,))),
+        read=explicit(ibtidaa=9, waqf=9),
+        phonemes="r i d a:",
+        char_rules={"ا": R("naql", "madd_iwad", "madd_tabii")},
+        sound_rules={"a:": R("naql", "madd_iwad", "madd_tabii")},
+    ),
+    # Warsh: كِتَٰبِيَهْۖ إِنِّے
+    Case(
+        id="kitabiyah-tahqiq",
+        site=Site(warsh=("69:19", (9, 10))),
+        read=explicit(ibtidaa=9, waqf=10),
+        phonemes=("k i t a: b i j a h", "ʔ i ñ i:"),
+        sound_rules={"ñ": R("ghunnah_mushaddadah")},
+        absent_char_rules={"ه": R("naql"), "إ": R("naql")},
+        absent_sound_rules={"ʔ": R("naql"), "h": R("naql")},
+    ),
+)
+
+
+@pytest.mark.parametrize("run", case_runs(CASES))
+def test_warsh_naql(run):
+    assert_case(run)

--- a/tests/phonemize/hamza/test_warsh_naql.py
+++ b/tests/phonemize/hamza/test_warsh_naql.py
@@ -22,9 +22,12 @@ CASES = (
         "joined": Expect(
             read=explicit(ibtidaa=1, wasl=2),
             phonemes=("q aˤ d a", "f l a ħ a"),
-            char_rules={"ا": R("naql"), "@fatha[2]": R("naql")},
+            char_rules={"ا": R("naql")},
             sound_rules={"a[1]": R("naql")},
-            absent_char_rules={"د": R("qalqala_sughra"), "ف": R("naql")},
+            absent_char_rules={
+                "د": R("qalqala_sughra"), "@fatha[2]": R("naql"),
+                "ف": R("naql"),
+            },
         ),
         "stopped-before": Expect(
             read=explicit(ibtidaa=1, waqf=(1, 2)),
@@ -50,15 +53,16 @@ CASES = (
         site=Site(warsh=("77:12", (2, 3))),
         read=explicit(ibtidaa=2, waqf=3),
         phonemes=("j a w m i n u", "ʒʒ i l a t"),
-        char_rules={"ا": R("naql"), "@round_zero": R("naql")},
+        char_rules={"ا": R("naql")},
         sound_rules={"u": R("naql")},
+        absent_char_rules={"@round_zero": R("naql")},
     ),
-    # Warsh: بَغَتِ
+    # Warsh: بَغَتِ اِحْد۪يٰهُمَا
     Case(
         id="feminine-taa",
-        site=Site(warsh=("49:9", (9,))),
+        site=Site(warsh=("49:9", (9, 10))),
         read=explicit(ibtidaa=9, waqf=10),
-        phonemes="b a ɣ aˤ t i",
+        phonemes=("b a ɣ aˤ t i", "ħ d a j a: h u m a:"),
         sound_rules={"i": R("naql")},
         absent_sound_rules={"t": R("naql")},
     ),
@@ -68,8 +72,9 @@ CASES = (
         site=Site(warsh=("6:151", (2, 3))),
         read=explicit(ibtidaa=2, wasl=3),
         phonemes=("t a ʕ a: l a w a", "t l u"),
-        char_rules={"ا[3]": R("naql"), "@fatha[4]": R("naql")},
+        char_rules={"ا[3]": R("naql")},
         sound_rules={"a[3]": R("naql")},
+        absent_char_rules={"@fatha[4]": R("naql")},
         absent_sound_rules={"w": R("naql")},
     ),
     # Warsh: اِ۬لَارْضِ

--- a/tests/phonemize/hamza/test_warsh_naql.py
+++ b/tests/phonemize/hamza/test_warsh_naql.py
@@ -34,7 +34,7 @@ CASES = (
             absent_sound_rules={"ʔ": R("naql")},
         ),
     }),
-    # Warsh: عَذَابٌ اَلِيمُۢ
+    # Warsh: عَذَابٌ اَلِيمٞۖ
     Case(
         id="tanwin-noon",
         site=Site(warsh=("2:104", (11, 12))),
@@ -44,7 +44,7 @@ CASES = (
         sound_rules={"a[2]": R("naql")},
         absent_sound_rules={"n": R("izhar")},
     ),
-    # Warsh: يَوْمٍ ا۟جِّلَتْ
+    # Warsh: يَوْمٍ ا۟جِّلَتْ
     Case(
         id="tanwin-damm",
         site=Site(warsh=("77:12", (2, 3))),
@@ -97,13 +97,13 @@ CASES = (
             sound_rules={"a": R("naql")},
         ),
     }),
-    # Warsh: رِداٗ يُصَدِّقْنِےٓۖ
+    # Warsh: رِداٗ يُصَدِّقْنِےٓۖ
     Case(
         id="ridan-joined",
         site=Site(warsh=("28:34", (9, 10))),
         read=explicit(ibtidaa=9, waqf=10),
         phonemes=("r i d a", "j̃ u sˤ aˤ dd i q Q n i:"),
-        char_rules={"@fathatan": R("naql", "idgham_bi_ghunnah")},
+        char_rules={"@fathatan": R("naql")},
         sound_rules={
             "a": R("naql"), "j̃": R("idgham_bi_ghunnah"),
             "Q": R("qalqala_sughra"),
@@ -118,7 +118,7 @@ CASES = (
         char_rules={"ا": R("naql", "madd_iwad", "madd_tabii")},
         sound_rules={"a:": R("naql", "madd_iwad", "madd_tabii")},
     ),
-    # Warsh: كِتَٰبِيَهْۖ إِنِّے
+    # Warsh: كِتَٰبِيَهْۖ إِنِّے
     Case(
         id="kitabiyah-tahqiq",
         site=Site(warsh=("69:19", (9, 10))),

--- a/tests/phonemize/nasal/test_izhar.py
+++ b/tests/phonemize/nasal/test_izhar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.support import Case, R, Site, assert_case, case_runs, isolated, joining, pick, through
+from tests.support import Case, R, Site, assert_case, case_runs, isolated, joining, through
 
 
 MUTLAQ = (
@@ -42,25 +42,6 @@ CASES = (
         char_rules={"ن[1]": R("izhar"), "@fathatan": R("izhar")},
         sound_rules={"n[1]": R("izhar"), "n[3]": R("izhar")},
     ),
-    # Warsh: قَوْلاً
-    Case(
-        id="ghayn",
-        site=Site(warsh=("2:59", (4,))),
-        read=joining(),
-        phonemes="q aˤ w l a n",
-        char_rules={"@fathatan": R("izhar")},
-        sound_rules={"n": R("izhar")},
-    ),
-    # Hafs: وَيَنْـَٔوْنَ
-    # Warsh: وَيَنْـَٔوْنَ
-    Case(
-        id="hamza-within-word",
-        site=Site.shared("6:26", (4,)),
-        read=joining(),
-        phonemes="w a j a n ʔ a w n a",
-        char_rules={"ن[1]": R("izhar")},
-        sound_rules={"n[1]": R("izhar")},
-    ),
     # Hafs: قِرَدَةً خَـٰسِـِٔينَ
     # Warsh: قِرَدَةً خَٰسِـِٕينَۖ
     Case(
@@ -92,15 +73,12 @@ CASES = (
         sound_rules={"n": R("izhar")},
     ),
     # Hafs: قَدِيرٌ
-    # Warsh: حِسَابٍۖ
     Case(
         id="verse-seam",
-        site=Site(hafs=("2:106", (19,)), warsh=("3:37", (34,))),
+        site=Site(hafs=("2:106", (19,))),
         read=joining(),
-        phonemes=pick(hafs="q aˤ d i: rˤ u n", warsh="ħ i s a: b i n"),
-        char_rules=pick(
-            hafs={"@dammatan": R("izhar")}, warsh={"@kasratan": R("izhar")}
-        ),
+        phonemes="q aˤ d i: rˤ u n",
+        char_rules={"@dammatan": R("izhar")},
         sound_rules={"n": R("izhar")},
     ),
     # Hafs: ٱلدُّنْيَا ۖ

--- a/tests/phonemize/nasal/test_izhar.py
+++ b/tests/phonemize/nasal/test_izhar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.support import Case, R, Site, assert_case, case_runs, isolated, joining, through
+from tests.support import Case, R, Site, assert_case, case_runs, isolated, joining, pick, through
 
 
 MUTLAQ = (
@@ -34,14 +34,32 @@ CASES = (
         sound_rules={"n[1]": R("izhar"), "n[2]": R("izhar")},
     ),
     # Hafs: يَكُنْ غَنِيًّا أَوْ
-    # Warsh: يَّكُنْ غَنِيّاً اَوْ
     Case(
         id="ghayn-hamza",
-        site=Site.shared("4:135", (16, 17, 18)),
+        site=Site(hafs=("4:135", (16, 17, 18))),
         read=through(),
         phonemes=("j a k u n", "ɣ aˤ n i jj a n", "ʔ a w"),
         char_rules={"ن[1]": R("izhar"), "@fathatan": R("izhar")},
         sound_rules={"n[1]": R("izhar"), "n[3]": R("izhar")},
+    ),
+    # Warsh: قَوْلاً
+    Case(
+        id="ghayn",
+        site=Site(warsh=("2:59", (4,))),
+        read=joining(),
+        phonemes="q aˤ w l a n",
+        char_rules={"@fathatan": R("izhar")},
+        sound_rules={"n": R("izhar")},
+    ),
+    # Hafs: وَيَنْـَٔوْنَ
+    # Warsh: وَيَنْـَٔوْنَ
+    Case(
+        id="hamza-within-word",
+        site=Site.shared("6:26", (4,)),
+        read=joining(),
+        phonemes="w a j a n ʔ a w n a",
+        char_rules={"ن[1]": R("izhar")},
+        sound_rules={"n[1]": R("izhar")},
     ),
     # Hafs: قِرَدَةً خَـٰسِـِٔينَ
     # Warsh: قِرَدَةً خَٰسِـِٕينَۖ
@@ -74,13 +92,15 @@ CASES = (
         sound_rules={"n": R("izhar")},
     ),
     # Hafs: قَدِيرٌ
-    # Warsh: قَدِيرٌۖ
+    # Warsh: حِسَابٍۖ
     Case(
         id="verse-seam",
-        site=Site.shared("2:106", (19,)),
+        site=Site(hafs=("2:106", (19,)), warsh=("3:37", (34,))),
         read=joining(),
-        phonemes="q aˤ d i: rˤ u n",
-        char_rules={"@dammatan": R("izhar")},
+        phonemes=pick(hafs="q aˤ d i: rˤ u n", warsh="ħ i s a: b i n"),
+        char_rules=pick(
+            hafs={"@dammatan": R("izhar")}, warsh={"@kasratan": R("izhar")}
+        ),
         sound_rules={"n": R("izhar")},
     ),
     # Hafs: ٱلدُّنْيَا ۖ

--- a/tests/phonemize/vowels/madd/test_iwad.py
+++ b/tests/phonemize/vowels/madd/test_iwad.py
@@ -71,11 +71,16 @@ CASES = (
         "joined": Expect(read=joining(), phonemes="ɣ aˤ f u: rˤ u n"),
         "stopped": Expect(read=isolated(), phonemes="ɣ aˤ f u: rˤ"),
     }),
-    # Hafs: قَوْمٍ
-    # Warsh: قَوْمٍ
-    StateCase(id="kasratan-negative", site=Site.shared("13:7", (14,)), states={
-        "joined": Expect(read=joining(), phonemes="q aˤ w m i n"),
-        "stopped": Expect(read=isolated(), phonemes="q aˤ w m"),
+    # Hafs: لِقَوْمٍ
+    # Warsh: لِقَوْمٍ
+    StateCase(id="kasratan-negative", site=Site.shared("5:41", (23,)), states={
+        "joined": Expect(
+            read=joining(),
+            phonemes=pick(
+                hafs="l i q aˤ w m i n", warsh="l i q aˤ w m i n a:"
+            ),
+        ),
+        "stopped": Expect(read=isolated(), phonemes="l i q aˤ w m"),
     }),
 )
 

--- a/tests/phonemize/vowels/madd/test_iwad.py
+++ b/tests/phonemize/vowels/madd/test_iwad.py
@@ -74,12 +74,7 @@ CASES = (
     # Hafs: لِقَوْمٍ
     # Warsh: لِقَوْمٍ
     StateCase(id="kasratan-negative", site=Site.shared("5:41", (23,)), states={
-        "joined": Expect(
-            read=joining(),
-            phonemes=pick(
-                hafs="l i q aˤ w m i n", warsh="l i q aˤ w m i n a:"
-            ),
-        ),
+        "joined": Expect(read=joining(), phonemes="l i q aˤ w m i n"),
         "stopped": Expect(read=isolated(), phonemes="l i q aˤ w m"),
     }),
 )

--- a/tests/phonemize/vowels/madd/test_iwad.py
+++ b/tests/phonemize/vowels/madd/test_iwad.py
@@ -71,11 +71,11 @@ CASES = (
         "joined": Expect(read=joining(), phonemes="ɣ aˤ f u: rˤ u n"),
         "stopped": Expect(read=isolated(), phonemes="ɣ aˤ f u: rˤ"),
     }),
-    # Hafs: لِقَوْمٍ
-    # Warsh: لِقَوْمٍ
-    StateCase(id="kasratan-negative", site=Site.shared("5:41", (23,)), states={
-        "joined": Expect(read=joining(), phonemes="l i q aˤ w m i n"),
-        "stopped": Expect(read=isolated(), phonemes="l i q aˤ w m"),
+    # Hafs: قَوْمٍ
+    # Warsh: قَوْمٍ
+    StateCase(id="kasratan-negative", site=Site.shared("13:7", (14,)), states={
+        "joined": Expect(read=joining(), phonemes="q aˤ w m i n"),
+        "stopped": Expect(read=isolated(), phonemes="q aˤ w m"),
     }),
 )
 

--- a/tests/phonemize/vowels/madd/test_leen.py
+++ b/tests/phonemize/vowels/madd/test_leen.py
@@ -11,7 +11,6 @@ from tests.support import (
     case_runs,
     isolated,
     joining,
-    pick,
 )
 
 
@@ -28,9 +27,7 @@ CASES = (
     # Hafs: قُرَيْشٍ
     # Warsh: قُرَيْشٍ
     StateCase(id="yaa", site=Site.shared("106:1", (2,)), states={
-        "joined": Expect(read=joining(),
-                         phonemes=pick(hafs="q u rˤ aˤ j ʃ i n",
-                                       warsh="q u rˤ aˤ j ʃ i n i:"),
+        "joined": Expect(read=joining(), phonemes="q u rˤ aˤ j ʃ i n",
                          absent_char_rules={"ي": R("madd_leen")}),
         "stopped": Expect(read=isolated(), phonemes="q u rˤ aˤ j ʃ",
                           char_rules={"ي": R("madd_leen")},

--- a/tests/phonemize/vowels/madd/test_leen.py
+++ b/tests/phonemize/vowels/madd/test_leen.py
@@ -11,6 +11,7 @@ from tests.support import (
     case_runs,
     isolated,
     joining,
+    pick,
 )
 
 
@@ -27,7 +28,9 @@ CASES = (
     # Hafs: قُرَيْشٍ
     # Warsh: قُرَيْشٍ
     StateCase(id="yaa", site=Site.shared("106:1", (2,)), states={
-        "joined": Expect(read=joining(), phonemes="q u rˤ aˤ j ʃ i n",
+        "joined": Expect(read=joining(),
+                         phonemes=pick(hafs="q u rˤ aˤ j ʃ i n",
+                                       warsh="q u rˤ aˤ j ʃ i n i:"),
                          absent_char_rules={"ي": R("madd_leen")}),
         "stopped": Expect(read=isolated(), phonemes="q u rˤ aˤ j ʃ",
                           char_rules={"ي": R("madd_leen")},


### PR DESCRIPTION
Third vertical of the Warsh program, stacked on #61. Adds the `naql` rule end to end: general cross-word transfer, the article family, the lexical exceptions, and the register conformance.

## Rule and model
- New global `Rule.NAQL` (definitions entry included) emitted only by the Warsh `RuleSet` through two generic classifiers in `rules/naql.py`: `Naql` (cross-word, boundary-aware) and `CarriedNaql` (annotation-driven, state-independent). Neither branches on the riwayah.
- Joined speech realizes the qata's A/U/I on the sakin host and silences the qata onset; a stop before the qata or a start on it restores the full hamza from the canonical structure. The occurrence names the qata as source and the host as host, and reaches the transferred vowel sound.
- New `Annotation.NAQL` marks hosts whose carried vowel is canonical in every state (the article family, `ردءا`); the classifier emits a classification-only occurrence there.

## Script supply (single-script policy)
- `riwayat/warsh/naql_script.py` owns the reviewed spellings: word-initial bare-alif latent qata (written haraka, damm stroke, and badal-dagger families), demotion of the host's written moved haraka to a naql witness, and the article shapes (wasl-marked, prefixed bare, the 22 suppressed-alif `لِلْ` forms, and the two interrogative `ءَالَٰنَ` tokens, whose istifham prefix stays untouched).
- The long article bases (`الآخرة` family, 214 tokens) are a reviewed closed set; everything else reads the short transferred vowel. Prefixed article-naql words now project their wasl onset, clearing the residue noted on #61.
- `ردءا` 28:34 gets its latent-qata responsibility from a new authored `data/riwayat/warsh/ledger.yaml`; the `كتابيه إني` boundary is excluded from the general classifier by authored data so the default reads tahqiq.

## Interactions fixed along the way
- Qalqala no longer releases a sakin a boundary rule has voweled (`qada aflaha` has no echo on the dal).
- Madd classification skips a vowel a boundary rule deleted, so a silenced badal qata is not classified.
- The analysis ownership layer treats a carrier silenced by naql like a silah drop, so `اُوتِيَ`-type words keep a complete source derivation.

## Tests and registers
- `tests/phonemize/hamza/test_warsh_naql.py`: the boundary matrix on `قد أفلح`, all four host kinds (consonant, tanwin noon incl. the U damm-stroke row, feminine taa, leen waw), the article joined/ibtidaa/waqf states, `ردءا` both states, and the kitabiyah tahqiq default - each with phonemes plus exact char/sound reach.
- `tests/conformance/test_warsh_registers.py`: the mechanical latent register (1,868 within-ayah + 325 adjacent-ayah boundaries, every host reconciled), the article register at exactly the documented 1,307 (1,283 + 22 + 2), and the kitabiyah-only full-hamza edge. The research doc's 1,550/180 subtotals are not reproducible from the supplied families under any principled cut; `docs/conformance.md` records the mechanical totals as superseding, plus the dad-qalqala and `عاداً الاولى` deltas.
- Adapter tests cover the latent families, the naql-stroke vs wasl-sign distinction, witness demotion, restoration shape, the article annotation, and non-claimed lookalikes (`قَالَا`, the eased `جَآءَ ا۟لَ`).
- `naql` is Warsh-only in the published catalogues; rule coverage asserts it fires under the Warsh ruleset and stays out of the Hafs one.

Full `python tools/gates.py` is green.
