### PR TITLE
feat: add Warsh madd badal and leen-mahmuz vertical

### DIFF
--- a/docs/warsh/madd-iteration-log.md
+++ b/docs/warsh/madd-iteration-log.md
@@ -1,0 +1,19 @@
+# Madd badal and leen-mahmuz iteration log
+
+This records the test-first reconciliation for delivery-map order 7. Domain
+expectations come from `research/v2/madd-badal.md` and
+`research/v2/madd-leen-mahmuz.md`, not from the previous runtime output.
+
+| Failure or discrepancy | Classification | Resolution |
+| --- | --- | --- |
+| The raw source census had 304 leen-mahmuz candidates, while canonical adjacency exposed only 303. | Adapter defect | Added the missing source-only-alif bridge for `لِشَاْےْءٍ`; canonical and runtime reconciliation now proves 304 candidates and 302 emissions. |
+| Initial U- and I-badal spellings projected a carrier consonant instead of a long qata. | Adapter defect | Project the reviewed initial-badal sequence as a long hamza nucleus and attach its written waw or yaa as the carrier. The 227-site A/U/I source register remains independently counted. |
+| Binding ordinary badal also emitted `madd_tabii`; pure single-hamza ibdal risked being called badal. | Classifier defect | Warsh treats badal as the effective ordinary classification, while transformed badal receives an explicit semantic-origin annotation. Pure ibdal remains `ibdal_hamza + madd_tabii`. |
+| Started wasl-plus-root-hamza forms initially collided with ordinary `madd_tabii`. | Classifier interaction | Added a start-only badal classifier and made ordinary madd stand down only for that exact realized-wasl/silent-root shape. Joined forms retain ordinary ibdal plus `madd_tabii`. |
+| The folded `يُوَ۬اخِذُ` slot initially put both ibdal and badal on `/a:/`. | Attribution defect | Attribute `ibdal_hamza` to the replacement `/w/` and `madd_badal` to the independently owned `/a:/` carrier. |
+| Existing iwad and ordinary-leen rows changed because their hidden following word begins an initial badal and now participates in naql. | Test ownership defect | Moved those unrelated negatives to clean exact corpus sites. The new naql-modified badal has its own visible two-word semantic row. |
+| `مَأْو۪يٰهُم` and `مَأْو۪يٰكُم` fail their pre-existing taqlil expectations. | Later vertical | Reproduced unchanged at clean `84d38ab`; order 10 inclination owns these two failures. No order-7 expectation or runtime rule was changed to hide them. |
+
+The leen register is independently partitioned as 297 ordinary, five plural
+Saw'at, and two exact exclusions. Duration faces and route correlations remain
+outside the runtime.

--- a/docs/warsh/research/v2/madd-badal.md
+++ b/docs/warsh/research/v2/madd-badal.md
@@ -47,11 +47,13 @@ For a realized hamza plus carrier:
   adjacency and the occurrence's source slot rather than by tagging `/ʔ/`.
 
 When the hamza is transformed, the transformation and applicable madd
-occurrences retain their own identities. `ibdal_hamza` names the replaced
-hamza as its source and the carrier it creates or lengthens as its host. The
-result sound exposes all applicable rules; visible placements follow sound
-ownership, so tests must not demand that every rule be copied onto every
-source glyph participating in the derivation.
+occurrences retain their own identities. `ibdal_hamza` names the sound that
+replaces the hamza; `madd_badal` independently names the after-hamza long. In
+`يُوَ۬اخِذُ`, therefore, `/w/` receives `ibdal_hamza` while `/a:/`
+receives `madd_badal`. Where ibdal itself creates or lengthens a carrier, that
+long instead exposes `ibdal_hamza`. Visible placements follow sound ownership,
+so tests must not demand that every rule be copied onto every source glyph
+participating in the derivation.
 
 The pausal overlap is visible in `مَـَٔابٖۖ`, selected source `13:30:8`,
 canonical `13:29:8`:

--- a/docs/warsh/status.md
+++ b/docs/warsh/status.md
@@ -7,6 +7,11 @@ source of truth for delivery order, relevant specifications, current state,
 and the PR or branch carrying each unit. A concluded research item is ready
 to implement; it is not evidence that its runtime vertical exists.
 
+Every runtime workstream follows the mandatory
+[`vertical-methodology.md`](vertical-methodology.md): establish the domain
+contract, inspect the selected script and its code-point families, author the
+complete tests before production code, then implement from projection upward.
+
 ## Delivery map
 
 | Order | Workstream | Relevant research and contract | Status | PR or branch |
@@ -17,7 +22,7 @@ to implement; it is not evidence that its runtime vertical exists.
 | 4 | Wasl and iltiqa: start registers, U subregister, silent-qata starts, and boundary repair | [`wasl-hamza.md`](research/v2/wasl-hamza.md), [`iltiqa.md`](research/v2/iltiqa.md) | **Complete** | [PR #61](https://github.com/Hetchy/Quranic-Phonemizer/pull/61) (merged) |
 | 5 | Naql: general, article, lexical, and boundary-specific transfer | [`naql.md`](research/v2/naql.md) | **Complete** | [PR #62](https://github.com/Hetchy/Quranic-Phonemizer/pull/62) (merged) |
 | 6 | Hamza core: generic ibdal/tashil primitives and Warsh single hamza | [`single-hamza.md`](research/v2/single-hamza.md), [`phoneme-rule-inventory.md`](research/v2/phoneme-rule-inventory.md) | **Complete** | `feat/warsh-hamza-core`; variant-bearing `allai` deferred to order 14 |
-| 7 | Madd badal and leen mahmuz. Implements badal mughayar bin-naql tests deferred in #62 | [`madd-badal.md`](research/v2/madd-badal.md), [`madd-leen-mahmuz.md`](research/v2/madd-leen-mahmuz.md), [`madd-counts.md`](research/v2/madd-counts.md) | **Pending** | Follows hamza core |
+| 7 | Madd badal and leen mahmuz. Implements badal mughayar bin-naql tests deferred in #62 | [`madd-badal.md`](research/v2/madd-badal.md), [`madd-leen-mahmuz.md`](research/v2/madd-leen-mahmuz.md), [`madd-counts.md`](research/v2/madd-counts.md) | **Complete** | `feat/warsh-phonemizer`; see [`madd-iteration-log.md`](madd-iteration-log.md) |
 | 8 | Hamza meetings | [`hamza-meetings.md`](research/v2/hamza-meetings.md) | **Pending** | Follows madd badal and leen mahmuz |
 | 9 | Joined-only and pausal shapes: mim al-jam, yaa zawaid, and seven alifs | [`mim-al-jam.md`](research/v2/mim-al-jam.md), [`yaa-zawaid.md`](research/v2/yaa-zawaid.md), [`seven-alifs.md`](research/v2/seven-alifs.md) | **Pending** | One mark-driven vertical, after hamza meetings |
 | 10 | Inclination: taqlil, kubra, fath, registers, and precedence | [`inclination.md`](research/v2/inclination.md) | **Pending** | Follows joined-only and pausal shapes |

--- a/docs/warsh/vertical-methodology.md
+++ b/docs/warsh/vertical-methodology.md
@@ -1,0 +1,142 @@
+# Warsh vertical methodology
+
+This document defines the required workflow for every Warsh runtime vertical.
+It applies to fixed behavior first and to selectable behavior when the variants
+workstream begins. The owning v2 research file remains the domain authority;
+[`research/v2/script-projection.md`](research/v2/script-projection.md) remains
+the source-to-canonical contract, and [`../../tests/README.md`](../../tests/README.md)
+remains the semantic-test format contract.
+
+## 1. Establish the domain contract
+
+Before changing tests or runtime code, read the owning v2 research document
+and its cited sources. Write down the vertical's complete decision surface:
+
+- the fixed rule and every accepted face;
+- wasl, waqf, ibtidaa, and internal-boundary behavior;
+- regular predicates, lexical families, closed exceptions, and exact scopes;
+- sound, rule, source, and host ownership;
+- interactions with earlier and later verticals;
+- behavior implemented now, accepted variants deferred to the variants
+  workstream, and behavior owned by a later vertical.
+
+Do not derive an expected pronunciation from current phonemizer output. The
+runtime is evidence about the present implementation, not a domain source.
+
+## 2. Inspect the selected script
+
+Inspect the exact King Fahd Warsh text and Unicode code points for every
+representative sequence before authoring its expectation. The inspection must
+cover the whole grapheme sequence, not an isolated scalar, and must determine
+whether each source element:
+
+- supplies a canonical letter, onset, nucleus, nunation, annotation, or
+  boundary shape;
+- attests an independently derived reading;
+- decorates an owned unit; or
+- is structural and carries no lexical unit.
+
+Corpus searches must identify lookalike sequences, prefixes, suffixes, and
+exceptional contexts. A scalar or visual mark does not receive one global
+meaning merely because it is frequent.
+
+Warsh is intentionally supported in one selected script. A reviewed source
+sequence may therefore supply a canonical fact directly when the script writes
+that fact or a stable reading-specific convention. This is not the Hafs
+two-script agreement problem: Warsh does not need a script-independent
+derivation merely to simulate a second script that is not supported.
+
+The permission is bounded. Script evidence does not by itself decide a public
+variant, a boundary-dependent performance, a madd classification, or another
+rule outside projection. Unreviewed sequences fail projection rather than
+receiving a best-effort interpretation. Research predicates and independently
+generated counts remain conformance checks on any script-supplied register.
+
+## 3. Use comparisons as diagnostics
+
+When a form is ambiguous, compare whichever independent evidence is useful for
+that case:
+
+- the equivalent Hafs source spelling and its code points;
+- the Hafs canonical score or performed phoneme output;
+- another published mushaf or trustworthy cross-reading presentation; and
+- related inflections and spellings elsewhere in the Warsh corpus.
+
+These comparisons can reveal a selected-script convention, missing written
+detail, a genuine riwayah difference, or a current adapter defect. They are
+diagnostic rather than automatically authoritative: the Warsh research and
+selected Warsh script still decide the Warsh expectation.
+
+## 4. Write the complete tests first
+
+All tests for the vertical must be authored before production implementation
+begins. The pre-implementation test set includes:
+
+1. semantic cases for every distinct rule, morphology, and boundary state;
+2. adapter fixtures for every selected-script sequence family and dangerous
+   lookalike;
+3. negative cases proving that nearby forms are not claimed;
+4. independently derived conformance registers and family subtotals; and
+5. interaction cases whose dependency belongs to another vertical.
+
+Semantic cases use exact corpus text and domain-derived phonemes. Prefer one
+isolated word when the rule is word-internal. Include multiple words only when
+the boundary is part of the behavior, and make the complete boundary plan and
+both words visible.
+
+Use representative semantic cases for distinct meanings and morphological
+forms. Exhaustive locations belong in conformance tests instead of repeated
+semantic rows. Fixed behavior must not absorb an accepted variant, and a
+variant-bearing form must not receive a convenient fixed expectation.
+
+Run the focused tests before implementation and record the failure partition.
+A correct expectation may fail because this vertical is absent or because a
+scheduled later vertical owns part of the result. Keep the correct expectation
+and state that dependency explicitly; do not rewrite it to match incomplete
+runtime output or hide a broad family behind permanent xfails.
+
+No classifier, source register, canonical pass, or rule binding is added until
+this test set has been reviewed against the research and selected script.
+
+## 5. Implement from projection upward
+
+Implement only the behavior established by the tests, in this order:
+
+1. recognize and validate reviewed selected-script sequences;
+2. project their canonical facts and exact source evidence;
+3. add any required typed canonical or performance vocabulary;
+4. implement the smallest generic classifier that expresses the domain rule;
+5. bind it through the Warsh package with authored predicates or exceptions;
+6. project rule reach to the responsible source, host, and performed sound; and
+7. add public selection only in the variants workstream.
+
+Do not create a classifier name that combines independent rules. Ibdal, madd,
+inclination, coloring, assimilation, and boundary changes retain separate
+owners even when they reach the same sound. Do not add implementation-authored
+locations merely to make a corpus total or current output pass.
+
+## 6. Reconcile and validate
+
+After implementation:
+
+- run the semantic and adapter tests first;
+- inspect every changed failure as a domain or projection question before
+  changing an expectation; record every iteration and whether the test or
+  implementation resolved it;
+- reconcile implementation registers against the independent conformance
+  derivation and its family subtotals;
+- run `python tools/gates.py --fast` while iterating; and
+- run `python tools/gates.py` before handoff unless the delivery explicitly
+  carries narrow, documented failures owned by a scheduled later vertical.
+
+A vertical is complete only when its research contract, selected-script
+projection, semantic cases, negative cases, registers, runtime behavior, rule
+reach, and applicable gates agree. Green tests produced by copying current
+output are not completion evidence.
+
+## 7. Handoff
+
+The pull request states what is implemented, what is deferred, and the exact
+validation state. Update [`status.md`](status.md) only when the workstream state
+changes. Variants remain deferred until the variants workstream unless the
+delivery map explicitly changes their order.

--- a/quranic_phonemizer/model/canon.py
+++ b/quranic_phonemizer/model/canon.py
@@ -10,7 +10,6 @@ from enum import StrEnum
 
 from .address import Location, Riwayah, SlotId, SpellingRunId, VariantSelection
 
-
 class CanonLetter(StrEnum):
     """The 28 letters, plus HAMZA and TAA_MARBUTA.
 
@@ -119,6 +118,8 @@ class Annotation(StrEnum):
     lexical `ردءا`."""
     IBDAL = "ibdal"
     """This slot is the selected script's replacement for a lexical hamza."""
+    BADAL = "badal"
+    """This long retains an after-hamza origin after an independent change."""
 
 
 class VowelForm(StrEnum):
@@ -331,6 +332,7 @@ class Rule(StrEnum):
     MADD_LEEN = "madd_leen"
     MADD_IWAD = "madd_iwad"
     MADD_BADAL = "madd_badal"
+    MADD_LEEN_MAHMUZ = "madd_leen_mahmuz"
     MADD_SILAH = "madd_silah"
 
     IBDAL_HAMZA = "ibdal_hamza"
@@ -388,9 +390,8 @@ CLASSIFICATION_ONLY: frozenset[Rule] = frozenset(
         Rule.MADD_SILAH,
         Rule.MADD_MUTTASIL,
         Rule.MADD_MUNFASIL,
-        Rule.MADD_LAZIM,
-        Rule.MADD_ARID_LISSUKUN,
-        Rule.MADD_LEEN,
+        Rule.MADD_LAZIM, Rule.MADD_ARID_LISSUKUN,
+        Rule.MADD_LEEN, Rule.MADD_LEEN_MAHMUZ,
         Rule.IBDAL_HAMZA,
         Rule.IMALA,
         Rule.TASHIL,

--- a/quranic_phonemizer/model/definitions.py
+++ b/quranic_phonemizer/model/definitions.py
@@ -131,7 +131,11 @@ RULE_DEFINITIONS: dict[Rule, tuple[str, str, str]] = {
     ),
     Rule.MADD_BADAL: (
         "Madd Badal", "مد بدل",
-        "A long vowel on a hamza stands in for a second hamza the reading does not say.",
+        "A long vowel keeps its after-hamza identity when that hamza is realized or changed.",
+    ),
+    Rule.MADD_LEEN_MAHMUZ: (
+        "Madd Leen Mahmuz", "مد اللين المهموز",
+        "A quiescent waw or yaa after fatha is extended before a hamza in the same word.",
     ),
     Rule.MADD_SILAH: (
         "Madd Silah", "مد صلة",

--- a/quranic_phonemizer/riwayat/warsh/naql_script.py
+++ b/quranic_phonemizer/riwayat/warsh/naql_script.py
@@ -87,6 +87,25 @@ def project_latent_qata(text: str, entries: list) -> None:
         )
 
 
+def project_initial_badal(text: str, entries: list) -> None:
+    """Restore the qata and long nucleus written by an initial badal shape."""
+    quality = latent_qata_badal_quality(text)
+    if quality is None:
+        return
+    entries[0] = LetterEntry(CanonLetter.HAMZA)
+    entries[1] = MarkEntry(
+        role=f"badal_{quality.name.lower()}",
+        cls=GraphemeClass.SMALL_VOWEL,
+        fact=SlotFact.VOWEL_QUALITY,
+        value=Nucleus.long(quality),
+    )
+    if quality in {Quality.U, Quality.I} and len(entries) > 2:
+        entries[2] = LetterEntry(
+            CanonLetter.WAW if quality is Quality.U else CanonLetter.YA,
+            dagger_host=True,
+        )
+
+
 def demote_moved_haraka(text: str, entries: list, quality: Quality) -> None:
     """The host's written final haraka is the naql witness, not its own
     canonical vowel: the underlying host stays sakin."""

--- a/quranic_phonemizer/riwayat/warsh/rules.py
+++ b/quranic_phonemizer/riwayat/warsh/rules.py
@@ -20,9 +20,11 @@ from ...rules.lam_shamsiyyah import ArticleLam, ArticleShape
 from ...rules.madd import (
     IltiqaShortening,
     MaddClass,
+    MaddBadal,
     MaddLeen,
     MaddSilah,
 )
+from ...rules.warsh_madd import MaddLeenMahmuz, StartedBadal
 from ...rules.pausal_glide import PausalGlide
 from ...rules.meem_sakinah import GhunnahMushaddadah, MeemSakinah
 from ...rules.naql import CarriedNaql, Naql
@@ -47,6 +49,13 @@ _DAMM_START_REPAIR = {Quality.U: Quality.U}
 #: The `كتابيه إني` boundary reads tahqiq by default: haa stays sakin and
 #: the qata is fully realized, so the general transfer must not claim it.
 _NAQL_TAHQIQ = frozenset({Location(69, 20, 1)})
+
+# Canonical locations of مَوْئِلا and الْمَوْءُودَة.  Only the first waw of
+# the latter can satisfy the leen predicate; its following long remains badal.
+_LEEN_MAHMUZ_EXCLUDED = frozenset({
+    Location(18, 58, 19),
+    Location(81, 8, 2),
+})
 
 
 def _article(tables) -> ArticleShape:
@@ -96,9 +105,12 @@ def _build() -> RuleSet:
             Phase.LENGTH: (
                 PausalGlide(),
                 IltiqaShortening(),
-                MaddClass(),
+                MaddClass(badal_is_effective=True),
                 MaddClass(additive_arid=True),
-                MaddLeen(),
+                MaddLeen(mahmuz_is_distinct=True),
+                MaddLeenMahmuz(excluded=_LEEN_MAHMUZ_EXCLUDED),
+                MaddBadal(),
+                StartedBadal(),
                 MaddSilah(),
                 IwadLength(),
             ),

--- a/quranic_phonemizer/riwayat/warsh/sequence.py
+++ b/quranic_phonemizer/riwayat/warsh/sequence.py
@@ -141,6 +141,7 @@ def _project_orthographic_silence(text, entries) -> None:
         ("إِيْه", 3),
         ("إِےْ", 3),
         ("اْيْـٔ", 1),
+        ("اْےْء", 1),
     ):
         start = text.find(pattern)
         if start >= 0:
@@ -152,7 +153,11 @@ def _project_orthographic_silence(text, entries) -> None:
     if start >= 0:
         _silence_mark(entries, start + 3)
 
-    for pattern, relative in (("ليْل", 2), ("اْيْـٔ", 3)):
+    for pattern, relative in (
+        ("ليْل", 2),
+        ("اْيْـٔ", 3),
+        ("اْےْء", 3),
+    ):
         start = text.find(pattern)
         if start >= 0:
             _consonantal_sukun(entries, start + relative)
@@ -197,6 +202,7 @@ def _entries(inventory: Inventory, text: str) -> list:
     entries = [inventory.classify(char) for char in text]
     _release_combining_hamza_seats(inventory, text, entries)
     wasl = _wasl_sequence(text, entries)
+    naql_script.project_initial_badal(text, entries)
     naql_script.project_latent_qata(text, entries)
     naql_script.project_article_naql(text, entries)
     naql_script.project_verse_final_host(text, entries)

--- a/quranic_phonemizer/riwayat/warsh/single_hamza.py
+++ b/quranic_phonemizer/riwayat/warsh/single_hamza.py
@@ -155,13 +155,16 @@ def supply_single_hamza(reading, drafts, lexicon, scribe, selection) -> None:
     for word, (location, span) in enumerate(
         zip(reading.words, word_spans(reading, drafts))
     ):
-        family = fixed_ibdal_family(_word_text(reading, word))
+        text = _word_text(reading, word)
+        family = fixed_ibdal_family(text)
         if family is not None:
             _fixed_target(family, span).annotations |= {Annotation.IBDAL}
             continue
         index = supplied_ibdal().get(location)
         if index is not None:
             span[index].annotations |= {Annotation.IBDAL}
+            if "وَ۬ا" in text:
+                span[index].annotations |= {Annotation.BADAL}
 
 
 __all__ = [

--- a/quranic_phonemizer/rules/madd.py
+++ b/quranic_phonemizer/rules/madd.py
@@ -5,20 +5,12 @@ from dataclasses import dataclass
 
 from ..engine.neighbourhood import Neighbourhood
 from ..engine.plan import (
-    Classify,
-    Length,
-    Phase,
-    Plan,
-    Realize,
-    Relength,
-    Verdict,
-    mint,
+    Classify, Length, Phase, Plan, Realize, Relength, Verdict, mint,
 )
 from ..model.address import BoundaryPlan, Junction, KhilafId, Location, SlotId
 from ..model.canon import Annotation, CanonLetter as L
 from ..model.canon import Onset, Quality, Rule, SlotOrigin, VowelForm
 from ..model.performance import Aspect, Occurrence, Vowel
-
 @dataclass(frozen=True, slots=True)
 class MaddLazimIbdal:
     """Name the hamza replaced by the long alif at madd-tasheel sites."""
@@ -191,6 +183,7 @@ class MaddClass:
     phase: Phase = Phase.LENGTH
     triggers: frozenset = frozenset({VowelForm.LONG, Onset.WASL})
     additive_arid: bool = False
+    badal_is_effective: bool = False
     emits: frozenset = frozenset({
         Rule.MADD_TABII, Rule.MADD_MUTTASIL, Rule.MADD_MUNFASIL,
         Rule.MADD_LAZIM, Rule.MADD_ARID_LISSUKUN,
@@ -202,6 +195,10 @@ class MaddClass:
     ) -> Verdict | None:
         slot = near.slot(at)
         if not self.additive_arid and slot is not None and plan.relengthened_long(at):
+            if self.badal_is_effective and _is_started_badal(
+                near, plan, slot, boundaries
+            ):
+                return None
             return _tabii(slot, at, None)
         found = _madd_of(near, plan, at, boundaries)
         if self.additive_arid:
@@ -216,6 +213,17 @@ class MaddClass:
         if found is None:
             return None
         rule, other = found
+        if (
+            self.badal_is_effective
+            and rule is Rule.MADD_TABII
+            and slot is not None
+            and (
+                slot.letter is L.HAMZA
+                or Annotation.BADAL in slot.annotations
+                or _is_started_badal(near, plan, slot, boundaries)
+            )
+        ):
+            return None
         if rule is not Rule.MADD_TABII:
             return _classify(rule, at, other)
         return _tabii(slot, at, other)
@@ -235,7 +243,10 @@ class MaddBadal:
         boundaries: BoundaryPlan,
     ) -> Verdict | None:
         slot = near.slot(at)
-        if slot is None or slot.letter is not L.HAMZA:
+        if slot is None or (
+            slot.letter is not L.HAMZA
+            and Annotation.BADAL not in slot.annotations
+        ):
             return None
         # the ibdal case: the plan carries a length the Score does not
         if _madd_of(near, plan, at, boundaries) is None and not plan.relengthened_long(at):
@@ -243,6 +254,24 @@ class MaddBadal:
         return Verdict(
             Occurrence(mint(Rule.MADD_BADAL, at), Rule.MADD_BADAL, (at,)), ()
         )
+
+
+def _is_started_badal(near, plan: Plan, slot, boundaries: BoundaryPlan) -> bool:
+    word = near.word_of(slot.id)
+    if (
+        word is None
+        or slot.onset is not Onset.WASL
+        or not boundaries.started_on(word)
+        or not near.first_of_word(slot.id)
+        or not plan.relengthened_long(slot.id)
+    ):
+        return False
+    root = near.after(slot.id)
+    return bool(
+        root is not None
+        and root.letter is L.HAMZA
+        and root.nucleus.is_silent
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -281,6 +310,7 @@ class MaddLeen:
     """
 
     rule: Rule = Rule.MADD_LEEN
+    mahmuz_is_distinct: bool = False
     phase: Phase = Phase.LENGTH
     triggers: frozenset = frozenset({L.WAW, L.YA})
     emits: frozenset = frozenset({Rule.MADD_LEEN, Rule.MADD_LAZIM})
@@ -303,6 +333,8 @@ class MaddLeen:
             return None
         following = near.after(at)
         if following is None:
+            return None
+        if self.mahmuz_is_distinct and following.letter is L.HAMZA:
             return None
         if following.nucleus.is_silent:
             # `عٓ` has a permanent sakin, so its length is obligatory.

--- a/quranic_phonemizer/rules/naql.py
+++ b/quranic_phonemizer/rules/naql.py
@@ -37,7 +37,7 @@ class Naql:
             return None
         if slot.letter is not CanonLetter.HAMZA or slot.onset is not Onset.PLAIN:
             return None
-        if slot.nucleus.is_silent or slot.nucleus.sounds_long:
+        if slot.nucleus.is_silent:
             return None
         if not near.first_of_word(at):
             return None
@@ -50,16 +50,20 @@ class Naql:
         if near.score.words[word].location in self.excluded:
             return None
         vowel = Vowel(slot.nucleus.quality)
+        effects = [
+            Realize(host.id, Aspect.VOWEL, vowel),
+            Silence(at, Aspect.CONSONANT),
+        ]
+        # A modified badal transfers the qata's quality but retains the long
+        # carrier whose after-hamza origin MaddBadal classifies independently.
+        if not slot.nucleus.sounds_long:
+            effects.append(Silence(at, Aspect.VOWEL))
         return Verdict(
             Occurrence(
                 mint(Rule.NAQL, at), Rule.NAQL, (at, host.id),
                 boundary=word - 1,
             ),
-            (
-                Realize(host.id, Aspect.VOWEL, vowel),
-                Silence(at, Aspect.CONSONANT),
-                Silence(at, Aspect.VOWEL),
-            ),
+            tuple(effects),
         )
 
 

--- a/quranic_phonemizer/rules/single_hamza.py
+++ b/quranic_phonemizer/rules/single_hamza.py
@@ -37,7 +37,15 @@ class SuppliedIbdal:
         slot = near.slot(at)
         if slot is None or Annotation.IBDAL not in slot.annotations:
             return None
-        aspect = Aspect.VOWEL if slot.nucleus.is_long else Aspect.CONSONANT
+        # A BADAL long belongs to the carrier after the changed hamza.  When
+        # the selected-script projection folds both into one slot (as in
+        # `يُوَ۬اخِذُ`), ibdal still names the replacement consonant, not
+        # that following long vowel.
+        aspect = (
+            Aspect.CONSONANT
+            if Annotation.BADAL in slot.annotations
+            else Aspect.VOWEL if slot.nucleus.is_long else Aspect.CONSONANT
+        )
         return Verdict(
             Occurrence(mint(Rule.IBDAL_HAMZA, at), Rule.IBDAL_HAMZA, (at,)),
             (Classify(at, aspect),),

--- a/quranic_phonemizer/rules/warsh_madd.py
+++ b/quranic_phonemizer/rules/warsh_madd.py
@@ -1,0 +1,80 @@
+"""Warsh-specific madd classifications and lexical exclusions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..engine.neighbourhood import Neighbourhood
+from ..engine.plan import Classify, Phase, Plan, Verdict, mint
+from ..model.address import BoundaryPlan, Location, SlotId
+from ..model.canon import CanonLetter as L
+from ..model.canon import Onset, Quality, Rule
+from ..model.performance import Aspect, Occurrence
+
+
+@dataclass(frozen=True, slots=True)
+class StartedBadal:
+    """Name the start-only badal created after a realized wasl onset."""
+
+    rule: Rule = Rule.MADD_BADAL
+    phase: Phase = Phase.LENGTH
+    triggers: frozenset = frozenset({Onset.WASL})
+    emits: frozenset = frozenset({Rule.MADD_BADAL})
+
+    def look(self, near: Neighbourhood, plan: Plan, at: SlotId,
+             boundaries: BoundaryPlan) -> Verdict | None:
+        slot, word = near.slot(at), near.word_of(at)
+        if (
+            slot is None or word is None or slot.onset is not Onset.WASL
+            or not boundaries.started_on(word) or not near.first_of_word(at)
+            or not plan.relengthened_long(at)
+        ):
+            return None
+        root = near.after(at)
+        if root is None or root.letter is not L.HAMZA or not root.nucleus.is_silent:
+            return None
+        return Verdict(
+            Occurrence(mint(Rule.MADD_BADAL, at), Rule.MADD_BADAL,
+                       (at, root.id)),
+            (Classify(at, Aspect.VOWEL),),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MaddLeenMahmuz:
+    """A same-word fatha plus sakin glide plus hamza, less two exclusions."""
+
+    excluded: frozenset[Location] = frozenset()
+    rule: Rule = Rule.MADD_LEEN_MAHMUZ
+    phase: Phase = Phase.LENGTH
+    triggers: frozenset = frozenset({L.WAW, L.YA})
+    emits: frozenset = frozenset({Rule.MADD_LEEN_MAHMUZ})
+
+    def look(self, near: Neighbourhood, plan: Plan, at: SlotId,
+             boundaries: BoundaryPlan) -> Verdict | None:
+        del plan, boundaries
+        slot, word = near.slot(at), near.word_of(at)
+        if slot is None or word is None:
+            return None
+        if near.score.words[word].location in self.excluded:
+            return None
+        if not slot.nucleus.is_silent or slot.onset is Onset.GEMINATE:
+            return None
+        before, following = near.before(at), near.after(at)
+        if before is None or following is None:
+            return None
+        if near.word_of(before.id) != word or near.word_of(following.id) != word:
+            return None
+        if not before.nucleus.is_short or before.nucleus.quality is not Quality.A:
+            return None
+        if following.letter is not L.HAMZA:
+            return None
+        return Verdict(
+            Occurrence(
+                mint(Rule.MADD_LEEN_MAHMUZ, at), Rule.MADD_LEEN_MAHMUZ,
+                (at,), (following.id,),
+            ),
+            (Classify(at, Aspect.CONSONANT),),
+        )
+
+
+__all__ = ["MaddLeenMahmuz", "StartedBadal"]

--- a/tests/adapter/test_warsh_script_projection.py
+++ b/tests/adapter/test_warsh_script_projection.py
@@ -253,10 +253,35 @@ def test_the_damm_stroke_after_a_bare_alif_is_the_qata_damm():
     ((6, 158, 23), Quality.I),
     ((10, 53, 5), Quality.I),
 ))
-def test_initial_badals_are_deferred_from_ordinary_naql(ref, quality):
-    entry, _ = _reading(ref)
+def test_initial_badals_project_a_long_qata_for_the_badal_vertical(ref, quality):
+    entry, reading = _reading(ref)
+    built = recitation(Riwayah.WARSH).build(reading)
+    first = next(
+        slot for slot in built.score.words[0].slots
+        if slot.letter is CanonLetter.HAMZA and slot.nucleus.is_long
+    )
+
     assert naql_script.latent_qata_badal_quality(entry.text) is quality
     assert naql_script.latent_qata_quality(entry.text) is None
+    assert first.letter is CanonLetter.HAMZA
+    assert first.nucleus.is_long
+    assert first.nucleus.quality is quality
+
+
+def test_the_yeh_barree_leen_bridge_keeps_only_the_glide():
+    location = Location(18, 23, 3)
+    text = json.loads(SOURCE.read_text(encoding="utf-8"))["18:24:3"]["text"]
+    reading = script_adapter(Script.UTHMANI).read(
+        location.verse, ((location, text),)
+    )
+    built = recitation(Riwayah.WARSH).build(reading)
+    lam, sheen, yaa, hamza, *_ = built.score.words[0].slots
+
+    assert "اْےْء" in text
+    assert sheen.letter is CanonLetter.SHEEN
+    assert sheen.nucleus == Nucleus.short(Quality.A)
+    assert yaa.letter is CanonLetter.YA and yaa.nucleus.is_silent
+    assert hamza.letter is CanonLetter.HAMZA
 
 
 def test_the_same_stroke_in_a_wasl_sequence_stays_the_start_quality():

--- a/tests/conformance/test_rule_coverage.py
+++ b/tests/conformance/test_rule_coverage.py
@@ -62,7 +62,7 @@ SAMPLE = (
 #:
 #: `naql` is Warsh-only: no Hafs classifier emits it, and
 #: `test_naql_is_warsh_bound_and_fires` asserts the Warsh side.
-DEFERRED: set[Rule] = {Rule.NAQL}
+DEFERRED: set[Rule] = {Rule.NAQL, Rule.MADD_LEEN_MAHMUZ}
 
 
 def _fired(packed, hafs, surah, ayah):
@@ -118,6 +118,27 @@ def test_naql_is_warsh_bound_and_fires():
     fired = {o.rule for o in perform(built.score, WARSH, plan).occurrences}
     assert Rule.NAQL in fired
     assert fired <= WARSH.emitted()
+
+
+def test_leen_mahmuz_is_warsh_bound_and_fires():
+    from quranic_phonemizer.api import recitation
+    from quranic_phonemizer.model.address import Script, VerseRef
+    from quranic_phonemizer.riwayat.warsh.rules import WARSH
+
+    assert Rule.MADD_LEEN_MAHMUZ in WARSH.emitted()
+    assert Rule.MADD_LEEN_MAHMUZ not in ruleset_for(Riwayah.HAFS).emitted()
+
+    package = recitation(Riwayah.WARSH)
+    verse = VerseRef(3, 49)
+    words = package.words(verse)
+    built = package.build(package.read(Script.UTHMANI, verse, words))
+    fired = {
+        occurrence.rule
+        for occurrence in perform(
+            built.score, WARSH, all_join(len(built.score.words))
+        ).occurrences
+    }
+    assert Rule.MADD_LEEN_MAHMUZ in fired
 
 
 @pytest.mark.parametrize("riwayah", list(Riwayah))

--- a/tests/conformance/test_warsh_registers.py
+++ b/tests/conformance/test_warsh_registers.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from quranic_phonemizer.api import recitation
+from quranic_phonemizer.engine.boundary_plan import all_join
 from quranic_phonemizer.model.address import Location, Riwayah, Script, VerseRef
 from quranic_phonemizer.model.canon import CanonLetter, Onset, Quality, Rule
 from quranic_phonemizer.phonemize.legacy_views import phonemes_by_word
@@ -32,6 +33,11 @@ HARAKA = {"َ": "A", "ُ": "U", "ِ": "I"}
 MARK_QUALITY = {"۬": "A", "۟": "U", "۪": "I"}
 TANWIN = set("ًٌٍٖٗٞ")
 STOP_SIGNS = "ۖۗۘۙۚۛۜ۩"
+
+LEEN_MAHMUZ_EXCLUSIONS = {"18:58:19", "81:8:2"}
+SAWAT = {
+    "7:20:10", "7:22:8", "7:26:8", "7:27:15", "20:121:5",
+}
 
 #: The one reviewed lexical start delta: Warsh reads the passive استحق.
 USTUHIQQA = "5:107:12"
@@ -518,14 +524,96 @@ def test_the_naql_latent_register_reconciles_with_canonical_hosts():
     }
 
 
-def test_the_227_initial_badals_are_deferred_from_ordinary_naql():
-    deferred = Counter(
+def test_the_227_initial_badals_have_the_reviewed_quality_register():
+    register = Counter(
         quality.name
         for entry in warsh_corpus().entries.values()
         if (quality := naql_script.latent_qata_badal_quality(entry.text))
         is not None
     )
-    assert deferred == Counter({"A": 177, "U": 47, "I": 3})
+    assert register == Counter({"A": 177, "U": 47, "I": 3})
+
+
+def test_the_selected_source_has_the_reviewed_304_leen_mahmuz_candidates():
+    raw = json.loads(WARSH_SOURCE.read_text(encoding="utf-8"))
+    families = {
+        "yaa_combining": ("ئْ", "يْـٔ"),
+        "yaa_barree": ("ےْء",),
+        "waw_bare": ("وْء",),
+        "waw_seated": ("وْئ",),
+    }
+    counts = Counter({
+        name: sum(
+            any(pattern in row["text"] for pattern in patterns)
+            for row in raw.values()
+        )
+        for name, patterns in families.items()
+    })
+    assert counts == Counter({
+        "yaa_combining": 84,
+        "yaa_barree": 202,
+        "waw_bare": 17,
+        "waw_seated": 1,
+    })
+    assert sum(counts.values()) == 304
+
+
+@pytest.mark.slow
+def test_the_canonical_leen_mahmuz_register_reconciles_to_302_emissions():
+    package = recitation(Riwayah.WARSH)
+    candidates: set[tuple[str, int]] = set()
+    emitted: set[tuple[str, int]] = set()
+    families = Counter()
+
+    for surah, counts in package.corpus.surah_info.items():
+        for ayah in range(1, len(counts) + 1):
+            verse = VerseRef(int(surah), ayah)
+            words = package.words(verse)
+            built = package.build(package.read(Script.UTHMANI, verse, words))
+            performance = package.perform(
+                built.score, all_join(len(built.score.words))
+            )
+            by_slot = {
+                slot.id: word.location
+                for word in built.score.words
+                for slot in word.slots
+            }
+            for word in built.score.words:
+                slots = word.slots
+                for index, slot in enumerate(slots[1:-1], 1):
+                    before, after = slots[index - 1], slots[index + 1]
+                    if not (
+                        slot.letter in {CanonLetter.WAW, CanonLetter.YA}
+                        and slot.nucleus.is_silent
+                        and before.nucleus.is_short
+                        and before.nucleus.quality is Quality.A
+                        and after.letter is CanonLetter.HAMZA
+                    ):
+                        continue
+                    key = (str(word.location), slot.id.ordinal)
+                    candidates.add(key)
+                    ref = str(word.location)
+                    if ref in LEEN_MAHMUZ_EXCLUSIONS:
+                        families["excluded"] += 1
+                    elif ref in SAWAT:
+                        families["sawat"] += 1
+                    else:
+                        families["ordinary"] += 1
+            emitted.update(
+                (str(by_slot[occurrence.subjects[0]]),
+                 occurrence.subjects[0].ordinal)
+                for occurrence in performance.occurrences
+                if occurrence.rule is Rule.MADD_LEEN_MAHMUZ
+            )
+
+    assert families == Counter({
+        "ordinary": 297,
+        "sawat": 5,
+        "excluded": 2,
+    })
+    assert len(candidates) == 304
+    assert len(emitted) == 302
+    assert emitted <= candidates
 
 
 def test_a_full_hamza_after_a_sakin_verse_end_is_only_kitabiyah():

--- a/tests/phonemize/hamza/test_wasl_start.py
+++ b/tests/phonemize/hamza/test_wasl_start.py
@@ -27,9 +27,18 @@ def qata_start_case(
                 "ئ" if warsh_carrier == "ي" else "ؤ": R("ibdal_hamza"),
             },
             hafs_indopak={"ا": R(start), "@hamza_mark": R("ibdal_hamza")},
-            warsh_uthmani={"ا": R(start), warsh_carrier: R("ibdal_hamza")},
+            warsh_uthmani={
+                "ا": R(start),
+                warsh_carrier: R("ibdal_hamza", "madd_badal"),
+            },
         ),
-        sound_rules={"ʔ": R(start), long_vowel: R("ibdal_hamza")},
+        sound_rules=pick(
+            hafs={"ʔ": R(start), long_vowel: R("ibdal_hamza")},
+            warsh={
+                "ʔ": R(start),
+                long_vowel: R("ibdal_hamza", "madd_badal"),
+            },
+        ),
     )
 
 

--- a/tests/phonemize/vowels/madd/test_iwad.py
+++ b/tests/phonemize/vowels/madd/test_iwad.py
@@ -63,6 +63,7 @@ CASES = (
                         "@inserted/ا": R("madd_iwad", "madd_tabii")},
             sound_rules={"a:[1]": R("madd_muttasil"),
                          "a:[2]": R("madd_iwad", "madd_tabii")},
+            absent_sound_rules={"a:[2]": R("madd_badal")},
         ),
     }),
     # Hafs: غَفُورٌ
@@ -72,9 +73,9 @@ CASES = (
         "stopped": Expect(read=isolated(), phonemes="ɣ aˤ f u: rˤ"),
     }),
     # Hafs: لِقَوْمٍ
-    # Warsh: لِقَوْمٍ
-    StateCase(id="kasratan-negative", site=Site.shared("5:41", (23,)), states={
-        "joined": Expect(read=joining(), phonemes="l i q aˤ w m i n"),
+    # Warsh: لِقَوْمٖ
+    StateCase(id="kasratan-negative", site=Site.shared("2:118", (23,)), states={
+        "joined": Expect(read=joining(), phonemes="l i q aˤ w m i"),
         "stopped": Expect(read=isolated(), phonemes="l i q aˤ w m"),
     }),
 )

--- a/tests/phonemize/vowels/madd/test_leen.py
+++ b/tests/phonemize/vowels/madd/test_leen.py
@@ -24,12 +24,12 @@ CASES = (
                           char_rules={"و": R("madd_leen")},
                           sound_rules={"w": R("madd_leen")}),
     }),
-    # Hafs: قُرَيْشٍ
-    # Warsh: قُرَيْشٍ
-    StateCase(id="yaa", site=Site.shared("106:1", (2,)), states={
-        "joined": Expect(read=joining(), phonemes="q u rˤ aˤ j ʃ i n",
+    # Hafs: بَيْنَ
+    # Warsh: بَيْنَ
+    StateCase(id="yaa", site=Site.shared("2:66", (4,)), states={
+        "joined": Expect(read=joining(), phonemes="b a j n a",
                          absent_char_rules={"ي": R("madd_leen")}),
-        "stopped": Expect(read=isolated(), phonemes="q u rˤ aˤ j ʃ",
+        "stopped": Expect(read=isolated(), phonemes="b a j n",
                           char_rules={"ي": R("madd_leen")},
                           sound_rules={"j": R("madd_leen")}),
     }),

--- a/tests/phonemize/vowels/madd/test_warsh_badal.py
+++ b/tests/phonemize/vowels/madd/test_warsh_badal.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.support import Case, R, Site, assert_case, case_runs, isolated, joining
+
+
+CASES = (
+    # Warsh: ءَادَمَ
+    Case(
+        id="ordinary",
+        site=Site(warsh=("2:31", (2,))),
+        read=isolated(),
+        phonemes="ʔ a: d a m",
+        char_rules={"ا": R("madd_badal")},
+        sound_rules={"a:": R("madd_badal")},
+        absent_sound_rules={"a:": R("madd_tabii")},
+    ),
+    # Warsh: مَـَٔابٖۖ
+    Case(
+        id="pausal-arid-overlap",
+        site=Site(warsh=("13:29", (8,))),
+        read=isolated(),
+        phonemes="m a ʔ a: b Q",
+        char_rules={"ا": R("madd_badal", "madd_arid_lissukun")},
+        sound_rules={"a:": R("madd_badal", "madd_arid_lissukun")},
+        absent_sound_rules={"a:": R("madd_tabii")},
+    ),
+    # Warsh: يُومِنُونَ
+    Case(
+        id="general-ibdal-is-not-badal",
+        site=Site(warsh=("2:3", (2,))),
+        read=isolated(),
+        phonemes="j u: m i n u: n",
+        char_rules={"و[1]": R("ibdal_hamza", "madd_tabii")},
+        sound_rules={"u:[1]": R("ibdal_hamza", "madd_tabii")},
+        absent_sound_rules={"u:[1]": R("madd_badal")},
+    ),
+    # Warsh: يُوَ۬اخِذُ
+    Case(
+        id="ibdal-changed-badal",
+        site=Site(warsh=("16:61", (2,))),
+        read=isolated(),
+        phonemes="j u w a: x i ð",
+        char_rules={
+            "و": R("ibdal_hamza"),
+            "ا": R("madd_badal"),
+        },
+        sound_rules={
+            "w": R("ibdal_hamza"),
+            "a:": R("madd_badal"),
+        },
+        absent_sound_rules={
+            "w": R("madd_badal"),
+            "a:": R("ibdal_hamza", "madd_tabii"),
+        },
+    ),
+    # Warsh: بَلَداً اٰمِناٗ (superscript alif after source alif, not maddah)
+    Case(
+        id="naql-changed-badal",
+        site=Site(warsh=("2:126", (7, 8))),
+        read=joining(),
+        phonemes=("b a l a d a n a", "a: m i n a"),
+        char_rules={
+            "ا[2]": R("naql"),
+            "@dagger_alif": R("madd_badal"),
+        },
+        sound_rules={"a:": R("madd_badal")},
+        absent_sound_rules={"a:": R("madd_tabii")},
+    ),
+    # Warsh: إِسْرَآءِيلَ
+    Case(
+        id="fixed-qasr-israel-keeps-badal",
+        site=Site(warsh=("2:40", (2,))),
+        read=isolated(),
+        phonemes="ʔ i s rˤ aˤ: ʔ i: l",
+        char_rules={"ي": R("madd_badal", "madd_arid_lissukun")},
+        sound_rules={"i:": R("madd_badal", "madd_arid_lissukun")},
+        absent_sound_rules={"i:": R("madd_tabii")},
+    ),
+    # Warsh: مَسْـُٔولاٗۖ
+    Case(
+        id="sakin-before-hamza-keeps-badal",
+        site=Site(warsh=("17:34", (17,))),
+        read=isolated(),
+        phonemes="m a s ʔ u: l a:",
+        char_rules={"و": R("madd_badal")},
+        sound_rules={"u:": R("madd_badal")},
+        absent_sound_rules={"u:": R("madd_tabii")},
+    ),
+)
+
+
+@pytest.mark.parametrize("run", case_runs(CASES))
+def test_warsh_madd_badal(run):
+    assert_case(run)

--- a/tests/phonemize/vowels/madd/test_warsh_leen_mahmuz.py
+++ b/tests/phonemize/vowels/madd/test_warsh_leen_mahmuz.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.support import Case, R, Site, assert_case, case_runs, isolated
+
+
+CASES = (
+    # Warsh: كَهَيْـَٔةِ
+    Case(
+        id="yaa-medial",
+        site=Site(warsh=("3:49", (16,))),
+        read=isolated(),
+        phonemes="k a h a j ʔ a h",
+        char_rules={"ي": R("madd_leen_mahmuz")},
+        sound_rules={"j": R("madd_leen_mahmuz")},
+        absent_char_rules={"@hamza_mark": R("madd_leen_mahmuz")},
+    ),
+    # Warsh: شَےْءٖ
+    Case(
+        id="yaa-final-hamza",
+        site=Site(warsh=("2:20", (24,))),
+        read=isolated(),
+        phonemes="ʃ a j ʔ",
+        char_rules={"ے": R("madd_leen_mahmuz")},
+        sound_rules={"j": R("madd_leen_mahmuz")},
+        absent_sound_rules={"j": R("madd_leen")},
+    ),
+    # Warsh: لِشَاْےْءٍ
+    Case(
+        id="yaa-source-alif-bridge",
+        site=Site(warsh=("18:23", (3,))),
+        read=isolated(),
+        phonemes="l i ʃ a j ʔ",
+        char_rules={"ے": R("madd_leen_mahmuz")},
+        sound_rules={"j": R("madd_leen_mahmuz")},
+    ),
+    # Warsh: سَوْءَٰتِهِمَاۖ (superscript alif after fatha, not maddah)
+    Case(
+        id="sawat-keeps-both-identities",
+        site=Site(warsh=("7:20", (10,))),
+        read=isolated(),
+        phonemes="s a w ʔ a: t i h i m a:",
+        char_rules={
+            "و": R("madd_leen_mahmuz"),
+            "@dagger_alif": R("madd_badal"),
+        },
+        sound_rules={
+            "w": R("madd_leen_mahmuz"),
+            "a:[1]": R("madd_badal"),
+        },
+    ),
+    # Warsh: مَوْئِلاٗۖ
+    Case(
+        id="mawilan-exclusion",
+        site=Site(warsh=("18:58", (19,))),
+        read=isolated(),
+        phonemes="m a w ʔ i l a:",
+        absent_char_rules={"و": R("madd_leen_mahmuz")},
+        absent_sound_rules={"w": R("madd_leen_mahmuz")},
+    ),
+    # Warsh: اَ۬لْمَوْءُۥدَةُ
+    Case(
+        id="mawudati-exclusion-and-second-waw-badal",
+        site=Site(warsh=("81:8", (2,))),
+        read=isolated(),
+        phonemes="ʔ a l m a w ʔ u: d a h",
+        sound_rules={"u:": R("madd_badal")},
+        absent_sound_rules={"w": R("madd_leen_mahmuz")},
+    ),
+)
+
+
+@pytest.mark.parametrize("run", case_runs(CASES))
+def test_warsh_madd_leen_mahmuz(run):
+    assert_case(run)


### PR DESCRIPTION
## Madd classifications

- Add Warsh madd badal as the effective classification, including fixed-qasr and changed-hamza forms.
- Implement badal mughayyar by naql and split ibdal ownership in يُوَ۬اخِذُ between the replacement waw and following badal carrier.
- Add same-word madd leen mahmuz with its reviewed lexical exclusions.

## Projection and coverage

- Restore initial-badal source shapes as long qata nuclei and preserve carrier provenance through naql.
- Reconcile 304 leen-mahmuz candidates to 302 emissions and cover ordinary, overlap, exclusion, boundary, and fixed-qasr families.
- Record the test-first vertical methodology and reconciliation log.

## Validation

- All comments, structure, cross-script, regression, roundtrip, attestation, and L1 gates pass at their ratchets.
- Focused Warsh badal and leen-mahmuz tests: 13 passed.
- Full suite: 2,982 passed and 14 skipped; the two existing tahqiq inclination failures for مَأْو۪يٰهُم and مَأْو۪يٰكُم reproduce unchanged on parent commit 84d38ab and remain assigned to the inclination vertical.