### PR TITLE
fix: use riwayah source coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,185 @@
-# Quranic Phonemizer
+# Qurʾanic Phonemizer
 
-Quranic Phonemizer converts Quran references into recitation-aware phonemes.
-It preserves the exact written text, resolved boundaries, performed sounds,
-tajweed rule occurrences, and source-to-sound relationships.
+<p align="center">
+  <a href="https://pypi.org/project/quranic-phonemizer/"><img src="https://img.shields.io/pypi/v/quranic-phonemizer" alt="PyPI version"></a>
+  <a href="https://quranicphonemizer.com/"><img src="https://img.shields.io/badge/Demo-quranicphonemizer.com-blue" alt="Website"></a>
+  <a href="https://openreview.net/forum?id=hZt0JK28iV"><img src="https://img.shields.io/badge/Paper-OpenReview-red" alt="Paper"></a>
+  <a href="https://github.com/Hetchy/Quranic-Phonemizer/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/quranic-phonemizer" alt="License"></a>
+</p>
 
-The package ships Hafs in Uthmani and IndoPak scripts and Warsh in Uthmani
-script. Python 3.11 or later is required.
+Qur'anic Grapheme-to-Phoneme (G2P) converter and tajweed annotator for the riwayat of Hafs 'An Asim and Warsh 'An Nafi', converting text to phoneme sequences with comprehensive support for waqf/intidaa transformations and tajweed breakdowns.
 
-## Install
+Use cases:
+
+- **Speech Recognition**: Phonetically transcribe recitations, create training data for machine learning systems
+- **Text-to-Speech**: Develop accurate TTS systems for Qurʾanic Arabic
+- **Linguistic & Tajweed Analysis**: Study phonological patterns and tajweed rule distributions across the Qurʾan, apply tajweed rule labels and coloring
+- **Educational Tools**: Build interactive applications for assessing Qur'an and tajweed pronunciation
+- **Timing Analysis**: Generate word-by-word timestamps for recitations, analyse madd/ghunnah durations
+
+## Table of Contents
+- [Phoneme Inventory](#phoneme-inventory)
+- [Quick start](#quick-start)
+- [Waqf](#waqf)
+- [Analysis](#analysis)
+- [Tajweed rules](#tajweed-rules)
+- [Contributing](#contributing)
+- [Credits](#credits)
+- [Citing](#citing)
+
+## Phoneme Inventory
+
+The phoneme inventory uses the standard International Phonetic Alphabet (IPA) [Arabic phonemes](https://en.wikipedia.org/wiki/Help%3AIPA/Arabic?utm_source=chatgpt.com) alongside custom phonemes for Tajweed rules. Hafs has 68 base phonemes plus 5 optional tokens; Warsh has 71 base phonemes plus 4 optional tokens.
+
+### Foundational Phonemes
+
+| **Letter**               | **Phoneme**              | **Letter** | **Phoneme**               | **Letter** | **Phoneme**              | **Letter** | **Phoneme**              |
+|:------------------------:|:------------------------|:----------:|:-------------------------|:----------:|:------------------------|:----------:|:------------------------|
+| أ , إ , ء , ؤ , ئ        | `ʔ`                      | د          | `d` / `dd`                | ض          | `dˤ` / `dˤdˤ`            | ك          | `k` / `kk`              |
+| ب                        | `b` / `bb`               | ذ          | `ð` / `ðð`                | ط          | `tˤ` / `tˤtˤ`            | ل          | `l` / `lˤ` / `ll` /  `lˤlˤ` |
+| ت                        | `t` / `tt`               | ر          | `r` / `rˤ` / `rr` / `rˤrˤ`| ظ          | `ðˤ` / `ðˤðˤ`            | م          | `m`                      |
+| ث                        | `θ` / `θθ`               | ز          | `z` / `zz`                | ع          | `ʕ` / `ʕʕ`               | ن          | `n`                      |
+| ج                        | `ʒ` / `ʒʒ`               | س          | `s` / `ss`                | غ          | `ɣ`                      | هـ         | `h` / `hh`               |
+| ح                        | `ħ` / `ħħ`               | ش          | `ʃ` / `ʃʃ`                | ف          | `f` / `ff`               | و          | `w` / `ww`               |
+| خ                        | `x` / `xx`               | ص          | `sˤ` / `sˤsˤ`             | ق          | `q` / `qq`               | ي , ى      | `j` / `jj`               |
+
+`lˤ` is the single emphatic lam used in Warsh. Gemination (shaddah) is represented by repeating the phoneme to create new distinct phonemes. Note that there is no gemination for `m` / `n` (modelled as tajweed instead), and for `ʔ` / `ɣ` (do not exist in the Qurʾān).
+
+### Vowel Phonemes
+
+| **Vowel**                      | **Phoneme**            |
+|:--------------------------------|:------------------------|
+| َ                              | `a`                    |
+| ُ                              | `u`                    |
+| ِ                              | `i`                    |
+| ا , ى                          | `aː` / `aˤː`           |
+| و                              | `uː`                   |
+| ي , ى                          | `iː`                   |
+| ى۪ Warsh Taqlil (Imala Sughra) | `ɛː`                   |
+
+### Tajweed Phonemes
+
+| **Rule**       | **Phoneme**                   |
+|----------------|:------------------------------|
+| Ikhfaa         | `ŋ`                           |
+| Ikhfaa shafawi | `ŋ` / `m̃`                    |
+| Iqlab          | `ŋ` / `m̃`                    |
+| Idgham         | `ñ` / `m̃` / `j̃` / `w̃`     |
+| Qalqala        | `Q`                           |
+
+Iqlab and ikhfaa shafawi use the open-lip nasal `ŋ` by default. Their nasal variants can instead select the closed-lip bilabial realization `m̃`, since both alternatives exist in recitations.
+
+### Extra Phonemes
+
+`extra_phonemes` selects toggleable output distinctions. Its default is empty to keep the default inventory compact; the underlying reading rule is unchanged.
+
+| **API option**              | **Phoneme**        | **Default** | **Notes** |
+|-----------------------------|:------------------|:-----------:|:---------|
+| `emphatic_fatha`            | `aˤ`              | Off         | Allophone |
+| `emphatic_ikhfaa`           | `ŋˤ`              | Off         | Heavy nasal allophone |
+| `qalqala_degree`            | `QQ`              | Off         | Stronger Qalqala kubra/akbar degree |
+| `tashil` (Hafs only)        | `ʔ̞`              | Off         | One case Hafs: `ءَا۬عْجَمِيٌّ` (41:44), off -> `ʔ` <br>Warsh always applies Tashil as `ʔ̞` since it is common |
+| `imala` (kubra)             | `e:`              | Off         | Hafs: `مَجْر۪ىٰهَا` (11:41), off -> `i:` <br> Warsh: `طَه۪` (20:1), off -> `ɛ:` |
+
+## Quick start
+
+Install the package and create a reader for the riwayah you need:
 
 ```bash
 pip install quranic-phonemizer
 ```
 
-## Quick start
-
 ```python
 from quranic_phonemizer import Phonemizer
 
-reader = Phonemizer()
-result = reader.analyse("2:255")
+hafs = Phonemizer()
+warsh = Phonemizer(riwayah="warsh")
+
+for name, reader, ref in (
+    ("Hafs 1:4", hafs, "1:4"),
+    ("Warsh 1:3", warsh, "1:3"),
+):
+    result = reader.analyse(ref)
+    print(name)
+    print(result.text())
+    print(" ".join(result.phonemes()))
+```
+
+```text
+Hafs 1:4
+مَـٰلِكِ يَوْمِ ٱلدِّينِ
+m a: l i k i j a w m i dd i: n
+
+Warsh 1:3
+مَلِكِ يَوْمِ اِ۬لدِّينِۖ
+m a l i k i j a w m i dd i: n
+```
+
+The phoneme sequences differ at one token:
+
+Hafs: m `a:` l i k i j a w m i dd i: n
+
+Warsh: m `a` l i k i j a w m i dd i: n
+
+### References
+
+`analyse()` accepts words, verses, surahs, and ranges:
+
+| Reference | Selection |
+| :--- | :--- |
+| `"1"` | Surah 1 |
+| `"1:3"` | Ayah 3 of surah 1 |
+| `"1:3:1"` | Word 1 of ayah 1:3 |
+| `"1:3-1:4"` | Ayahs 1:3 through 1:4 |
+| `"1:3-1:4:2"` | Ayah 1:3 through word 2 of 1:4 |
+| `"1-2:2"` | Surah 1 through ayah 2:2 |
+
+## Waqf
+
+Use `stop_signs` to apply waqf at mushaf signs and `stop_refs` to stop after exact words:
+
+```python
+hafs.analyse("68:33", stop_signs=("optional_stop",))
+hafs.analyse("2:255", stop_refs=("2:255:7",))
+```
+
+This applies waqf to `2:255:7` and ibtidaa to `2:55:8`, or any words with `ۚ ` in `68:33`, changing phonemes and tajweed rules accordingly.
+
+Note the first and last word of a request always apply ibtidaa and waqf respectively.
+
+`reader.available_stop_signs` gives the keys valid for that reader. Hafs uses:
+
+| Stop key | Sign |
+| :--- | :---: |
+| `preferred_continue` | ۖ |
+| `preferred_stop` | ۗ |
+| `optional_stop` | ۚ |
+| `compulsory_stop` | ۘ |
+| `prohibited_stop` | ۙ |
+| `either_stop` | ۛ |
+
+Warsh exposes only `optional_stop`ۖ
+
+## Analysis
+
+The phonemizer exposes more detailed analysis, breakdowns, relationships and rules:
+
+```python
+result = hafs.analyse("107:4")
 
 print(result.text())
 print(" ".join(result.phonemes()))
-print(result.phonemes(by="word"))
+print([occurrence.rule_id.value for occurrence in result.rule_occurrences])
 ```
 
-Use `stop_refs` for exact word-addressed stops or `stop_signs` for stop
-classes available in the selected riwayah and script:
-
-```python
-reader.analyse("1:1-1:3", stop_refs=("1:2:2",))
-reader.analyse("2:255", stop_signs=("preferred_stop", "optional_stop"))
+```text
+فَوَيْلٌ لِّلْمُصَلِّينَ
+f a w a j l u ll i l m u sˤ a ll i: n
+['waqf_diacritic_drop', 'idgham_bila_ghunnah', 'lam_qamariyyah',
+ 'izhar', 'madd_arid_lissukun', 'tafkheem']
 ```
 
-Configuration is stated once on `Phonemizer`:
-
-```python
-reader = Phonemizer(
-    riwayah="hafs",
-    script="uthmani",
-    variants={"iqlab_nasal": "bilabial"},
-    extra_phonemes=("emphatic_fatha", "emphatic_ikhfaa"),
-)
-```
-
-The configured catalogues show exactly what that reader accepts:
-
-```python
-reader.available_stop_signs
-reader.available_variants
-reader.tajweed_rules
-```
-
-## Selective projections
-
-Core analysis is eager. Source tokenization, highlights, and cells are built
-once on first use and cached on the result:
+The core records are available directly:
 
 ```python
 result.words
@@ -64,30 +187,87 @@ result.boundaries
 result.sounds
 result.rule_occurrences
 result.mergers
-
-source = result.source()
-groups = result.highlights()
-source_cells = result.cells(spelling="source")
-transformed_cells = result.cells(spelling="transformed")
 ```
 
-The native schema-v2 documents are available without serializer imports:
+The same result provides its source units, highlight groups, and transformed cells:
 
 ```python
-analysis = result.document("analysis_result")
-source = result.document("source_view")
-highlights = result.document("highlight_groups")
-cells = result.document("cell_view", spelling="transformed")
+source = result.source()
+highlights = result.highlights()
+cells = result.cells(spelling="transformed")
 ```
 
-See [docs/public-api.md](docs/public-api.md) for the complete contract,
-[docs/architecture.md](docs/architecture.md) for internals, and
-[docs/performance.md](docs/performance.md) for benchmarking guidance.
+The transformed view contains 19 columns. These are the columns carrying a rule, a spelling change, or shared sound presentation:
 
-## Development
+| Column | Text | Status | Rule occurrence | Owns | Presents |
+| ---: | :---: | --- | --- | --- | --- |
+| 7 | `ٌ` | `present` | `1 idgham_bila_ghunnah` | `6` | `7` |
+| 8 | `لّ` | `present` | `1 idgham_bila_ghunnah` | `7` | |
+| 10 | `لْ` | `present` | `2 lam_qamariyyah` | `9` | |
+| 14 | `ص` | `present` | `5 tafkheem` | `12` | |
+| 15 | `َ` | `present` | `5 tafkheem` | `13` | |
+| 17 | `ِ` | `present` | | | `15` |
+| 18 | `ي` | `present` | `4 madd_arid_lissukun` | `15` | |
+| 19 | `نْ` | `replaced` | `3 izhar` | `16` | |
+| 20 | `َ` | `dropped` | `0 waqf_diacritic_drop` | | |
 
-```bash
-python tools/gates.py --fast
+The first boundary bridges columns 7 and 8 through sound 7 and rule occurrence 1. IDs remain valid across the core analysis, source view, highlights, and cells.
+
+`document()` returns JSON-compatible schema 2 documents for the analysis and its projections. See the [public API reference](docs/public-api.md) for every record and field.
+
+## Tajweed rules
+
+The catalogue is scoped to the reader. Each definition provides an ID, English name, Arabic name, and summary:
+
+```python
+for rule in hafs.tajweed_rules:
+    print(rule.id.value, rule.name, rule.arabic_name, rule.summary)
+
+result.rule_definition("idgham_bila_ghunnah")
+result.rule_occurrences
 ```
 
-The project is licensed under the [MIT License](LICENSE).
+`rule_occurrences` contains the rules applied to that request. Hafs and Warsh share these published rule IDs:
+
+- Noon and tanween: `izhar`, `ikhfaa`, `iqlab`, `idgham_bi_ghunnah`, `idgham_bila_ghunnah`, `ghunnah_mushaddadah`
+- Meem sakinah: `izhar_shafawi`, `ikhfaa_shafawi`, `idgham_shafawi`
+- Assimilation and the definite article: `idgham_mutamathilayn`, `idgham_mutaqaribayn`, `idgham_mutajanisayn_kamil`, `idgham_mutajanisayn_naqis`, `lam_shamsiyyah`, `lam_qamariyyah`
+- Qalqala: `qalqala_sughra`, `qalqala_kubra`, `qalqala_akbar`
+- Tafkheem and tarqeeq: `tafkheem`, `tarqeeq`
+- Special readings: `imala`, `tashil`, `ishmam`
+- Madd: `madd_tabii`, `madd_muttasil`, `madd_munfasil`, `madd_lazim`, `madd_arid_lissukun`, `madd_leen`, `madd_iwad`, `madd_badal`, `madd_silah`
+- Hamza and adjacent sakin letters: `ibdal_hamza`, `hamza_wasl_silent`, `hamza_wasl_fatha`, `hamza_wasl_damma`, `hamza_wasl_kasra`, `iltiqa_haraka`, `iltiqa_shortening`
+- Waqf and silence: `waqf_diacritic_drop`, `waqf_silah_drop`, `waqf_taa_marbuta`, `pausal_alif` (seven alifs), `orthographic_silence` (rasm)
+
+Warsh adds five rule IDs:
+
+- `taqlil`
+- `madd_leen_mahmuz`
+- `madd_mim_al_jam`
+- `madd_yaa_zawaid`
+- `naql`
+
+## Contributing
+
+If you find any issues or have feature suggestions, please feel free to open an issue or submit a pull request.
+
+Future plans include support for other turuq and riwayat.
+
+## Credits
+
+The project makes use of the [Quranic Universal Library's (QUL) Hafs script](https://qul.tarteel.ai/resources/quran-script/312).
+
+## Citing
+
+If you use this phonemizer in your work, please cite [the paper](https://openreview.net/pdf?id=hZt0JK28iV) as follows:
+
+```bibtex
+@inproceedings{
+ibrahim2025quranic,
+title={Qur{\textquoteright}anic Phonemizer: Bringing Tajweed-Aware Phonemes to Qur{\textquoteright}anic Machine Learning},
+author={Ahmed Ibrahim},
+booktitle={5th Muslims in ML Workshop co-located with NeurIPS 2025},
+year={2025},
+url={https://openreview.net/forum?id=hZt0JK28iV}
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,7 +192,7 @@ Runtime resources are package data under
 what the data varies with:
 
 - `riwayat/hafs/corpus/` holds the packed source text and address metadata;
-- `riwayat/warsh/corpus/` holds the selected-source/public alignment;
+- `riwayat/warsh/corpus/` holds the selected-source/internal alignment;
 - `riwayat/hafs/scripts/` holds one total scalar inventory per shipped script;
 - `riwayat/warsh/scripts/` holds the King Fahd Warsh scalar inventory;
 - `riwayat/hafs/ledger.yaml` supplies authored canonical facts and script
@@ -203,9 +203,10 @@ what the data varies with:
 - `render/ipa.yaml` holds the output alphabet shared across riwayat.
 
 [`quranic_phonemizer/corpus.py`](../quranic_phonemizer/corpus.py) owns packed
-corpus decoding and aligned selected-source/public addressing. Aligned
-graphemes retain typed source-artifact locations while public lookup remains
-canonical. [`quranic_phonemizer/dataio.py`](../quranic_phonemizer/dataio.py)
+corpus decoding and selected-source lookup over the internal alignment.
+Aligned graphemes retain typed source-artifact locations while public lookup
+uses the selected script's coordinates.
+[`quranic_phonemizer/dataio.py`](../quranic_phonemizer/dataio.py)
 provides the strict YAML loader: duplicate keys, missing required keys, and
 unknown keys are errors at the relevant resource loaders.
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -87,6 +87,10 @@ result = reader.analyse(
 selects stop-advice classes. `stop_refs` selects exact word references. An
 empty tuple is valid for either option.
 
+References use the selected script's own ayah and word coordinates. The same
+passage can therefore have a different reference in another riwayah. Word
+records returned by the result use that same coordinate system.
+
 Stop classes are validated against the reader before boundary resolution.
 Unknown or unavailable names are collected, sorted, and reported by the public
 `UnknownStopSign` error together with the applicable catalogue. Reference

--- a/quranic_phonemizer/analysis/build.py
+++ b/quranic_phonemizer/analysis/build.py
@@ -113,7 +113,11 @@ def _build_words(
     for i, score_word in enumerate(session.score.words):
         words.append(Word(
             id=ids.WordId(i),
-            ref=str(score_word.location),
+            ref=(
+                session.public_refs[i]
+                if len(session.public_refs) == len(session.score.words)
+                else str(score_word.location)
+            ),
             text=texts[i],
             before_boundary_id=ids.BoundaryId(i),
             after_boundary_id=ids.BoundaryId(i + 1),

--- a/quranic_phonemizer/analysis/cells/view.py
+++ b/quranic_phonemizer/analysis/cells/view.py
@@ -330,7 +330,7 @@ def build_cell_view(
         (
             None
             if session.verse_ends is None
-            else frozenset(str(location) for location in session.verse_ends)
+            else session.verse_ends
         ),
     )
     if spelling == "transformed":

--- a/quranic_phonemizer/api.py
+++ b/quranic_phonemizer/api.py
@@ -98,7 +98,7 @@ class Recitation:
         return perform(score, self.rules, boundaries, selection=selection)
 
     def words(self, verse: VerseRef) -> tuple[tuple[Location, str], ...]:
-        """The words this riwayah performs at one public verse address."""
+        """The words at one internal canonical verse address."""
         return self.corpus.words(verse)
 
 

--- a/quranic_phonemizer/corpus.py
+++ b/quranic_phonemizer/corpus.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import array
+import bisect
 import gzip
 import json
 import struct
@@ -105,15 +106,31 @@ class PackedCorpus:
             raise ValueError(f"Reference selects no words: {reference}")
         return tuple(result)
 
+    @staticmethod
+    def public_ref(location: Location) -> str:
+        return str(location)
+
+    def verse_ends(self, locations: tuple[Location, ...]) -> frozenset[Location]:
+        return frozenset(
+            location
+            for location in locations
+            if location.word
+            == self.surah_info[str(location.surah)][location.ayah - 1]
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class AlignedCorpus:
-    """A corpus whose selected-source words are aligned to public locations."""
+    """A selected-source corpus aligned to internal canonical locations."""
 
     entries: Mapping[Location, AlignedWord]
     canonical_to_runtime: Mapping[Location, Location]
     by_verse: Mapping[VerseRef, tuple[Location, ...]]
     surah_info: Mapping[str, tuple[int, ...]]
+    source_to_runtime: Mapping[Location, Location]
+    source_locations: tuple[Location, ...]
+    source_by_verse: Mapping[VerseRef, tuple[Location, ...]]
+    source_verse_ends: frozenset[Location]
 
     def word(self, location: Location) -> str:
         try:
@@ -147,14 +164,33 @@ class AlignedCorpus:
         high = _canonical_endpoint(end, end=True)
         if low > high:
             raise ValueError(f"Reference starts after it ends: {reference}")
+        first = bisect.bisect_left(self.source_locations, Location(*low))
+        last = bisect.bisect_right(self.source_locations, Location(*high))
         result: list[Location] = []
-        for canonical, runtime in self.canonical_to_runtime.items():
-            key = (canonical.surah, canonical.ayah, canonical.word)
-            if low <= key <= high and (not result or result[-1] != runtime):
+        for source in self.source_locations[first:last]:
+            runtime = self.source_to_runtime[source]
+            if not result or result[-1] != runtime:
                 result.append(runtime)
         if not result:
             raise ValueError(f"Reference selects no words: {reference}")
         return tuple(result)
+
+    def public_ref(self, location: Location) -> str:
+        entry = self.entries[self.canonical_to_runtime[location]]
+        refs = tuple(
+            Location(source.location.surah, source.location.ayah,
+                     source.location.word)
+            for source in entry.sources
+        )
+        if len(refs) == 1:
+            return str(refs[0])
+        return f"{refs[0]}-{refs[-1]}"
+
+    def verse_ends(self, locations: tuple[Location, ...]) -> frozenset[Location]:
+        return frozenset(
+            location for location in locations
+            if location in self.source_verse_ends
+        )
 
     def sources_for(
         self, location: Location, text: str
@@ -254,10 +290,12 @@ def load_corpus(db_path: Path, info_path: Path) -> PackedCorpus:
 
 
 def load_aligned_corpus(path: Path, *, artifact: str) -> AlignedCorpus:
-    """Load the complete selected-source/public alignment artifact."""
+    """Load the complete selected-source/internal alignment artifact."""
     entries: dict[Location, AlignedWord] = {}
     canonical_to_runtime: dict[Location, Location] = {}
     by_verse: dict[VerseRef, list[Location]] = {}
+    source_to_runtime: dict[Location, Location] = {}
+    source_by_verse: dict[VerseRef, list[Location]] = {}
     canonical_verses: dict[int, int] = {}
     canonical_counts: dict[VerseRef, int] = {}
     with gzip.open(path, "rt", encoding="utf-8") as source:
@@ -286,37 +324,56 @@ def load_aligned_corpus(path: Path, *, artifact: str) -> AlignedCorpus:
             _bind_aligned_word(
                 path, line_number, canonical, sources,
                 entries, canonical_to_runtime, by_verse,
+                source_to_runtime, source_by_verse,
             )
 
     ordered = dict(sorted(entries.items()))
     frozen_by_verse = {
         verse: tuple(sorted(locations)) for verse, locations in by_verse.items()
     }
+    frozen_source_by_verse = {
+        verse: tuple(locations) for verse, locations in source_by_verse.items()
+    }
     return AlignedCorpus(
         MappingProxyType(ordered),
         MappingProxyType(dict(sorted(canonical_to_runtime.items()))),
         MappingProxyType(frozen_by_verse),
         MappingProxyType(_surah_info(canonical_verses, canonical_counts)),
+        MappingProxyType(dict(sorted(source_to_runtime.items()))),
+        tuple(sorted(source_to_runtime)),
+        MappingProxyType(frozen_source_by_verse),
+        frozenset(words[-1] for words in frozen_source_by_verse.values()),
     )
 
 
 def _bind_aligned_word(
     path, line_number, canonical, sources,
     entries, canonical_to_runtime, by_verse,
+    source_to_runtime, source_by_verse,
 ) -> None:
     if not canonical:
         raise ValueError(f"{path}:{line_number}: source-only row")
-    public = canonical[0]
-    if public in entries:
-        raise ValueError(f"{path}:{line_number}: duplicate {public}")
+    runtime = canonical[0]
+    if runtime in entries:
+        raise ValueError(f"{path}:{line_number}: duplicate {runtime}")
     for alias in canonical:
         if alias in canonical_to_runtime:
             raise ValueError(
                 f"{path}:{line_number}: duplicate canonical {alias}"
             )
-        canonical_to_runtime[alias] = public
-    entries[public] = AlignedWord(public, canonical, sources)
-    by_verse.setdefault(public.verse, []).append(public)
+        canonical_to_runtime[alias] = runtime
+    entries[runtime] = AlignedWord(runtime, canonical, sources)
+    by_verse.setdefault(runtime.verse, []).append(runtime)
+    for source in sources:
+        location = Location(
+            source.location.surah, source.location.ayah, source.location.word
+        )
+        if location in source_to_runtime:
+            raise ValueError(f"{path}:{line_number}: duplicate source {location}")
+        source_to_runtime[location] = runtime
+        verse_words = source_by_verse.setdefault(location.verse, [])
+        if not verse_words or verse_words[-1] != runtime:
+            verse_words.append(runtime)
 
 
 def _surah_info(canonical_verses, canonical_counts):

--- a/quranic_phonemizer/session/core.py
+++ b/quranic_phonemizer/session/core.py
@@ -37,8 +37,10 @@ class Session:
     letter_khilaf_sites: dict[Location, KhilafId] = field(default_factory=dict)
     """Where the reading's authored data sites a per-location letter khilaf,
     for a projection to tag; empty when a caller resolves without one."""
-    verse_ends: frozenset[Location] | None = None
+    verse_ends: frozenset[str] | None = None
     """Actual corpus verse-final words touched by this request."""
+    public_refs: tuple[str, ...] = ()
+    """The selected script's address for each internal score word."""
 
 
 def phonemize_request(
@@ -56,12 +58,17 @@ def phonemize_request(
     built = assemble_span(
         recitation, locations, script=script, selection=selection
     )
+    resolved_stop_refs = tuple(
+        str(location)
+        for stop_ref in stop_refs
+        for location in recitation.corpus.locations(stop_ref)
+    )
     boundaries = resolve_boundaries(
         built.inscription.advice,
         locations,
         built.score,
         stop_signs=stop_signs,
-        stop_refs=stop_refs,
+        stop_refs=resolved_stop_refs,
     )
     performance = recitation.perform(
         built.score, boundaries, selection=selection
@@ -73,11 +80,10 @@ def phonemize_request(
             for site in recitation.khilaf.canonical.letters
         },
         verse_ends=frozenset(
-            Location(
-                verse.surah,
-                verse.ayah,
-                recitation.corpus.surah_info[str(verse.surah)][verse.ayah - 1],
-            )
-            for verse in {location.verse for location in locations}
+            recitation.corpus.public_ref(location)
+            for location in recitation.corpus.verse_ends(locations)
+        ),
+        public_refs=tuple(
+            recitation.corpus.public_ref(location) for location in locations
         ),
     )

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,7 @@ not in the generic API catalogue test.
 
 ## Sites and riwayat
 
-Semantic sites use canonical/public coordinates:
+Semantic sites use canonical internal coordinates:
 
 ```python
 Site(hafs=("2:5", (3, 4)))
@@ -75,7 +75,8 @@ script that package ships. Use `pick()` only for a small script or riwayah
 difference under the same domain law. A different rule, scope, or explanation
 gets its own case.
 
-Source-corpus coordinates belong in adapter fixtures, not semantic sites.
+Source-corpus coordinates belong in adapter fixtures and public API tests, not
+semantic sites.
 For an explicit cross-ayah boundary, the focused word numbers may continue
 through the flattened next ayah; the case must provide the exact boundary
 plan so the seam is visible to the reviewer.

--- a/tests/adapter/test_warsh_corpus_alignment.py
+++ b/tests/adapter/test_warsh_corpus_alignment.py
@@ -1,4 +1,4 @@
-"""Selected-source words aligned to canonical/public Quran addresses."""
+"""Selected-source words aligned to internal canonical Quran addresses."""
 from __future__ import annotations
 
 import gzip
@@ -75,13 +75,30 @@ def test_only_the_reviewed_cardinality_spans_differ(artifact):
     }
 
 
-def test_runtime_lookup_is_public_and_provenance_is_source_typed():
+def test_runtime_lookup_is_internal_and_provenance_is_source_typed():
     aligned = corpus()
     entry = aligned.entries[Location(2, 3, 1)]
     assert entry.sources[0].location == SourceLocation(ARTIFACT, 2, 2, 1)
     assert aligned.words(VerseRef(2, 3))[0] == (entry.location, entry.text)
     with pytest.raises(ValueError, match="absent"):
         aligned.word(Location(1, 1, 1))
+
+
+def test_every_source_verse_resolves_in_its_own_coordinates(artifact):
+    _, rows = artifact
+    expected: dict[VerseRef, list[str]] = {}
+    for row in rows:
+        for source in row["source"]:
+            surah, ayah, _ = _key(source["ref"])
+            expected.setdefault(VerseRef(surah, ayah), []).append(source["text"])
+
+    aligned = corpus()
+    for verse, texts in expected.items():
+        locations = aligned.locations(str(verse))
+        assert locations == aligned.source_by_verse[verse]
+        assert " ".join(aligned.entries[location].text for location in locations) == (
+            " ".join(texts)
+        )
 
 
 def test_a_two_source_word_preserves_both_source_runs_and_the_separator():
@@ -97,15 +114,17 @@ def test_a_two_source_word_preserves_both_source_runs_and_the_separator():
     assert refs[-1].offset == len(entry.sources[1].text) - 1
 
 
-def test_each_coordinate_of_a_canonical_span_resolves_the_same_runtime_word():
+def test_source_requests_resolve_to_aligned_runtime_words():
     aligned = corpus()
     first = Location(15, 7, 1)
     second = Location(15, 7, 2)
+    third = Location(15, 7, 3)
 
     assert aligned.entries[first].canonical == (first, second)
     assert aligned.locations("15:7:1") == (first,)
-    assert aligned.locations("15:7:2") == (first,)
+    assert aligned.locations("15:7:2") == (third,)
+    assert aligned.public_ref(first) == "15:7:1"
     assert aligned.word(second) == aligned.word(first) == "لَّوْمَا"
     assert aligned.contains_full_verse(
-        first.verse, aligned.locations("15:7")
+        first.verse, aligned.by_verse[first.verse]
     )

--- a/tests/analysis/test_cell_projection.py
+++ b/tests/analysis/test_cell_projection.py
@@ -599,7 +599,7 @@ def test_warsh_naql_stays_on_the_written_host_haraka():
 def test_warsh_native_iqlab_meem_is_its_own_source_backed_cell():
     warsh = recitation(Riwayah.WARSH)
     pen = pen_for(warsh.inventory(Script.UTHMANI))
-    ref = "2:10-2:11"
+    ref = "2:9-2:10"
     session = phonemize_request(warsh, ref)
     kw = dict(ref=ref, riwayah="warsh", script="uthmani", variant={})
     bundle = build_bundle(session, **kw)

--- a/tests/analysis/test_source_view.py
+++ b/tests/analysis/test_source_view.py
@@ -175,10 +175,11 @@ def test_the_site_set_exercises_every_boundary_state(hafs):
 
 def test_warsh_optional_stop_is_a_typed_boundary_sign():
     warsh = recitation(Riwayah.WARSH)
+    ref = "1:3-1:4"
 
-    session = phonemize_request(warsh, "2:2")
+    session = phonemize_request(warsh, ref)
     bundle = build_bundle(
-        session, ref="2:2", riwayah="warsh", script="uthmani", variant={}
+        session, ref=ref, riwayah="warsh", script="uthmani", variant={}
     )
     view = build_source_view(session, bundle=bundle)
     sign = next(character for character in view.characters if character.text == "ۖ")
@@ -189,9 +190,9 @@ def test_warsh_optional_stop_is_a_typed_boundary_sign():
     assert boundary.stop_advice is StopAdvice.OPTIONAL_STOP
     assert boundary.state is BoundaryState.JOIN
 
-    stopped = phonemize_request(warsh, "2:2", stop_signs=("optional_stop",))
+    stopped = phonemize_request(warsh, ref, stop_signs=("optional_stop",))
     stopped_bundle = build_bundle(
-        stopped, ref="2:2", riwayah="warsh", script="uthmani", variant={}
+        stopped, ref=ref, riwayah="warsh", script="uthmani", variant={}
     )
     assert stopped_bundle.boundaries[sign.boundary_id.value].state is BoundaryState.STOP
 

--- a/tests/api/test_extra_phonemes.py
+++ b/tests/api/test_extra_phonemes.py
@@ -35,7 +35,7 @@ def test_hafs_tashil_defaults_off():
 
 
 def test_warsh_tashil_is_always_rendered_and_not_an_extra():
-    result = Phonemizer(riwayah="warsh").analyse("6:19:19")
+    result = Phonemizer(riwayah="warsh").analyse("6:20:19")
     assert "ʔ̞" in result.phonemes()
     assert result.analysis.extra_phonemes == frozenset()
 

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -220,12 +220,25 @@ def test_rule_lookup_is_scoped_to_the_selected_riwayah():
         result.rule_definition(unavailable)
 
 
+def test_warsh_requests_and_word_refs_use_its_source_coordinates():
+    reader = Phonemizer(riwayah="warsh")
+
+    result = reader.analyse("1:3")
+
+    assert result.text() == "مَلِكِ يَوْمِ اِ۬لدِّينِۖ"
+    assert tuple(word.ref for word in result.words) == (
+        "1:3:1",
+        "1:3:2",
+        "1:3:3",
+    )
+
+
 def test_warsh_stop_sign_is_typed_and_requested_by_its_catalogue_name():
     reader = Phonemizer(riwayah="warsh")
     ref = "1:4-1:5"
     joined = reader.analyse(ref)
     selected = reader.analyse(ref, stop_signs=("optional_stop",))
-    explicit = reader.analyse(ref, stop_refs=("1:4:3",))
+    explicit = reader.analyse(ref, stop_refs=("1:4:4",))
 
     boundary = next(item for item in joined.boundaries if item.stop_sign == "ۖ")
     assert boundary.stop_advice is StopAdvice.OPTIONAL_STOP


### PR DESCRIPTION
## Coordinates
- Resolve public references and stop references in the selected script's coordinate system.
- Keep canonical locations internal to alignment, tajweed, and phoneme processing.
- Return source-native word references and source-native verse edges.

## Documentation
- Compare Hafs 1:4 with Warsh 1:3 in the README.
- State the selected-script reference contract in the public API and architecture docs.

## Verification
- Cover every Warsh source verse against the pinned corpus.
- 2,796 tests passed, 12 skipped, and 3 expected failures with the unrelated wheel-layout assertion excluded.
- Comment, structure, and test-style gates pass.