### PR TITLE
fix: restore verse stop selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,21 +136,22 @@ Warsh: m `a` l i k i j a w m i dd i: n
 
 ## Waqf
 
-Use `stop_signs` to apply waqf at mushaf signs and `stop_refs` to stop after exact words:
+Use `verse` to stop at every ayah end in a range. Mushaf sign keys and exact
+word references can add other stops:
 
 ```python
+hafs.analyse("1:4-1:5", stop_signs=("verse",))
 hafs.analyse("68:33", stop_signs=("optional_stop",))
 hafs.analyse("2:255", stop_refs=("2:255:7",))
 ```
 
-This applies waqf to `2:255:7` and ibtidaa to `2:55:8`, or any words with `ۚ ` in `68:33`, changing phonemes and tajweed rules accordingly.
-
-Note the first and last word of a request always apply ibtidaa and waqf respectively.
+The first word always starts in ibtidaa. The last word always ends in waqf.
 
 `reader.available_stop_signs` gives the keys valid for that reader. Hafs uses:
 
 | Stop key | Sign |
 | :--- | :---: |
+| `verse` | ۝ |
 | `preferred_continue` | ۖ |
 | `preferred_stop` | ۗ |
 | `optional_stop` | ۚ |
@@ -158,25 +159,26 @@ Note the first and last word of a request always apply ibtidaa and waqf respecti
 | `prohibited_stop` | ۙ |
 | `either_stop` | ۛ |
 
-Warsh exposes only `optional_stop`ۖ
+Warsh also supports `verse`. Its only written stop-sign key is
+`optional_stop`, rendered as ۖ.
 
 ## Analysis
 
 The phonemizer exposes more detailed analysis, breakdowns, relationships and rules:
 
 ```python
-result = hafs.analyse("107:4")
+result = hafs.analyse("112:2")
 
 print(result.text())
 print(" ".join(result.phonemes()))
-print([occurrence.rule_id.value for occurrence in result.rule_occurrences])
+print(sorted({occurrence.rule_id.value for occurrence in result.rule_occurrences}))
 ```
 
 ```text
-فَوَيْلٌ لِّلْمُصَلِّينَ
-f a w a j l u ll i l m u sˤ a ll i: n
-['waqf_diacritic_drop', 'idgham_bila_ghunnah', 'lam_qamariyyah',
- 'izhar', 'madd_arid_lissukun', 'tafkheem']
+ٱللَّهُ ٱلصَّمَدُ
+ʔ a lˤlˤ aˤ: h u sˤsˤ a m a d Q
+['hamza_wasl_fatha', 'hamza_wasl_silent', 'lam_shamsiyyah', 'madd_tabii',
+ 'qalqala_kubra', 'tafkheem', 'waqf_diacritic_drop']
 ```
 
 The core records are available directly:
@@ -197,21 +199,15 @@ highlights = result.highlights()
 cells = result.cells(spelling="transformed")
 ```
 
-The transformed view contains 19 columns. These are the columns carrying a rule, a spelling change, or shared sound presentation:
+Here is the transformed cell view without its internal IDs:
 
-| Column | Text | Status | Rule occurrence | Owns | Presents |
-| ---: | :---: | --- | --- | --- | --- |
-| 7 | `ٌ` | `present` | `1 idgham_bila_ghunnah` | `6` | `7` |
-| 8 | `لّ` | `present` | `1 idgham_bila_ghunnah` | `7` | |
-| 10 | `لْ` | `present` | `2 lam_qamariyyah` | `9` | |
-| 14 | `ص` | `present` | `5 tafkheem` | `12` | |
-| 15 | `َ` | `present` | `5 tafkheem` | `13` | |
-| 17 | `ِ` | `present` | | | `15` |
-| 18 | `ي` | `present` | `4 madd_arid_lissukun` | `15` | |
-| 19 | `نْ` | `replaced` | `3 izhar` | `16` | |
-| 20 | `َ` | `dropped` | `0 waqf_diacritic_drop` | | |
+| Transformed cells | Phonemes | Changes | Rules |
+| :--- | :--- | :--- | :--- |
+| `أ` `َ` `ل` `لّ` `َ` `ٰ` `ه` `ُ` | `ʔ a lˤlˤ aˤ: h u` | Spoken hamza and fatha replace the opening wasl; madd is added | `hamza_wasl_fatha`, `lam_shamsiyyah`, `madd_tabii`, `tafkheem` |
+| ~~`ٱ`~~ `ل` `صّ` `َ` `م` `َ` `دْ` ~~`ُ`~~ | `sˤsˤ a m a d Q` | Wasl alif and final damma drop; final dal takes sukun | `hamza_wasl_silent`, `lam_shamsiyyah`, `tafkheem`, `qalqala_kubra`, `waqf_diacritic_drop` |
 
-The first boundary bridges columns 7 and 8 through sound 7 and rule occurrence 1. IDs remain valid across the core analysis, source view, highlights, and cells.
+The article lam merges into sad, producing `sˤsˤ`. Struck cells are retained
+for alignment but are not pronounced.
 
 `document()` returns JSON-compatible schema 2 documents for the analysis and its projections. See the [public API reference](docs/public-api.md) for every record and field.
 

--- a/docs/design/public-api-facade.md
+++ b/docs/design/public-api-facade.md
@@ -155,10 +155,11 @@ reader.available_variants
 reader.tajweed_rules
 ```
 
-`available_stop_signs` returns the stop-advice names accepted by this reader's
-`stop_signs` request argument. The names are derived from the selected
-`(riwayah, script)` inventory, not from a process-wide enum: each script
-authors its own subset and scalar mapping.
+`available_stop_signs` returns the names accepted by this reader's
+`stop_signs` request argument. Every reader includes the synthetic `verse`
+selector. The remaining names come from the selected `(riwayah, script)`
+inventory, not from a process-wide enum: each script authors its own subset
+and scalar mapping.
 `available_variants` lists only the selected riwayah's khilaf points and
 choices. `tajweed_rules` lists only rules the selected riwayah declares it can
 emit, followed by its published silence reasons.
@@ -168,15 +169,15 @@ The currently packaged stop-sign catalogues are explicit contract fixtures:
 ```python
 Phonemizer(riwayah="hafs", script="uthmani").available_stop_signs
 # (
-#     "preferred_continue", "preferred_stop", "optional_stop",
+#     "verse", "preferred_continue", "preferred_stop", "optional_stop",
 #     "compulsory_stop", "prohibited_stop", "either_stop",
 # )
 
 Phonemizer(riwayah="hafs", script="indopak").available_stop_signs
-# the same six names plus "permitted_stop"
+# the same seven names plus "permitted_stop"
 
 Phonemizer(riwayah="warsh", script="uthmani").available_stop_signs
-# ("optional_stop",)
+# ("verse", "optional_stop")
 ```
 
 The packaged Warsh Uthmani source contains U+06D6 `ۖ` 9,948 times. It is a
@@ -186,6 +187,10 @@ caller addresses it with `stop_signs=("optional_stop",)`. The resulting
 boundary exposes the exact `stop_sign="ۖ"` and
 `stop_advice=StopAdvice.OPTIONAL_STOP`. `stop_refs` remains available for
 explicit word-addressed stops.
+
+`verse` restores the legacy cross-ayah behavior without pretending that an
+ayah boundary is an inventory-authored stop-advice glyph. It stops after each
+selected source ayah in a multi-ayah request.
 
 The existing root functions may remain as explicit metadata queries:
 
@@ -209,7 +214,7 @@ Phonemizer(riwayah="warsh").analyse(
     stop_signs=("preferred_stop",),
 )
 # UnknownStopSign: ['preferred_stop'] is not available for warsh/uthmani;
-# available stop signs: ['optional_stop']
+# available stop signs: ['verse', 'optional_stop']
 ```
 
 `UnknownStopSign` is a public `ValueError`. Multiple unknown or unavailable
@@ -495,9 +500,9 @@ payload came from the facade or the current backend composition.
   `stop_sign` source character owned by its boundary.
 - Prove on corpus and focused fixtures that all 9,948 Warsh occurrences remain
   exact source text, become typed stop signs rather than generic separators,
-  and make an internal boundary stop only when `optional_stop` or an explicit
-  `stop_refs` request applies; the passage-final boundary retains its ordinary
-  mandatory stop.
+  and make an internal boundary stop only when `verse`, `optional_stop`, or an
+  explicit `stop_refs` request applies; the passage-final boundary retains its
+  ordinary mandatory stop.
 - Refactor internal construction so `AnalysisResult`, source,
   highlights, and cells share one facts/inscription/bundle state.
 - Keep existing builder functions callable and tested.
@@ -542,8 +547,8 @@ access tests are therefore part of this step rather than deferred facade tests.
   wiring, not a website API redesign.
 - Replace the website's process-wide default stop list with names from the
   configured `reader.available_stop_signs`. Preserve today's Hafs defaults.
-  Publish Warsh `optional_stop` as the name for its `ۖ` glyph; the UI may
-  submit that class or explicit word stops.
+  Publish `verse` for every reader and Warsh `optional_stop` as the name for
+  its `ۖ` glyph; the UI may submit either class or explicit word stops.
 - Publish the selected configuration's stop-sign, variant, and rule catalogues
   from `/api/meta`; the frontend must not reuse the Hafs catalogue for Warsh.
 - Keep the backend's Digital Khatt override as host presentation data; it must
@@ -582,12 +587,11 @@ access tests are therefore part of this step rather than deferred facade tests.
   riwayah;
 - no configured catalogue includes a value belonging only to another
   configuration;
-- Warsh Uthmani publishes exactly `optional_stop` for `ۖ`, accepts both
-  `stop_signs=()` and `stop_signs=("optional_stop",)`, reports the glyph and
-  `StopAdvice.OPTIONAL_STOP` on the native boundary, and continues to accept valid
-  `stop_refs`;
+- Warsh Uthmani publishes `verse` plus `optional_stop` for `ۖ`, accepts both
+  selectors, reports the glyph and `StopAdvice.OPTIONAL_STOP` on the native
+  boundary, and continues to accept valid `stop_refs`;
 - requesting `preferred_stop` for Warsh raises `UnknownStopSign` and reports
-  `optional_stop` as the exact available class;
+  `verse` and `optional_stop` as the exact available classes;
 - an invalid stop class for Hafs reports the selected script and the exact
   available values;
 - Invalid arguments raise stable, user-facing errors.
@@ -653,9 +657,9 @@ The facade is ready when all of the following are true:
    `build_source_view`, `build_cell_view`, or `pen_for`.
 4. Native DTOs and IDs remain unchanged.
 5. Stop-sign catalogues and validation are scoped by `(riwayah, script)`;
-   variant and rule catalogues are scoped by riwayah; Warsh Uthmani exposes
-   `optional_stop` for `ۖ` and supports both that class and `stop_refs` for
-   requested stops.
+   every reader exposes `verse`; variant and rule catalogues are scoped by
+   riwayah; Warsh Uthmani exposes `optional_stop` for `ۖ` and supports that
+   class, `verse`, and `stop_refs` for requested stops.
 6. The website backend uses only the facade and produces equivalent analysis,
    cells, text, phonemes, stops, and Digital Khatt data for the same requests.
 7. `phonemize()`, `PhonemizeResult`, public graph exports, alignment,

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -65,13 +65,14 @@ The packaged stop catalogues are:
 
 | Configuration | Stop classes |
 | --- | --- |
-| Hafs/Uthmani | `preferred_continue`, `preferred_stop`, `optional_stop`, `compulsory_stop`, `prohibited_stop`, `either_stop` |
+| Hafs/Uthmani | `verse`, `preferred_continue`, `preferred_stop`, `optional_stop`, `compulsory_stop`, `prohibited_stop`, `either_stop` |
 | Hafs/IndoPak | the Hafs/Uthmani classes plus `permitted_stop` |
-| Warsh/Uthmani | `optional_stop` |
+| Warsh/Uthmani | `verse`, `optional_stop` |
 
 Warsh Uthmani authors `ۖ` as `optional_stop`. The source character and its
 boundary retain that exact glyph and `StopAdvice.OPTIONAL_STOP` whether or not
-the caller selects the stop class.
+the caller selects the stop class. `verse` is a synthetic selector shared by
+all scripts; it stops at every ayah boundary in the requested range.
 
 ## Requests and stop plans
 
@@ -84,8 +85,8 @@ result = reader.analyse(
 ```
 
 `ref` may address one word, verse, surah, or same-depth range. `stop_signs`
-selects stop-advice classes. `stop_refs` selects exact word references. An
-empty tuple is valid for either option.
+selects `verse` or stop-advice classes. `stop_refs` selects exact word
+references. An empty tuple is valid for either option.
 
 References use the selected script's own ayah and word coordinates. The same
 passage can therefore have a different reference in another riwayah. Word

--- a/quranic_phonemizer/analysis/facade.py
+++ b/quranic_phonemizer/analysis/facade.py
@@ -45,6 +45,7 @@ _DEFAULT_SCRIPT = {
     Riwayah.WARSH: Script.UTHMANI,
 }
 _SPELLINGS = ("source", "transformed")
+_SYNTHETIC_STOP_SIGNS = ("verse",)
 
 
 class UnknownExtraPhoneme(ValueError):
@@ -79,7 +80,9 @@ def available_stop_signs(
         entry.advice for entry in inventory.marks.values()
         if entry.advice is not None
     }
-    return tuple(advice.value for advice in StopAdvice if advice in declared)
+    return _SYNTHETIC_STOP_SIGNS + tuple(
+        advice.value for advice in StopAdvice if advice in declared
+    )
 
 
 def available_variants(riwayah: str) -> dict[str, dict[str, object]]:

--- a/quranic_phonemizer/engine/boundary_plan.py
+++ b/quranic_phonemizer/engine/boundary_plan.py
@@ -5,7 +5,7 @@ Operates on per-word advice already extracted from the writing, not on a
 """
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from ..model.address import BoundaryPlan, Junction, Location
 from ..model.canon import Score
@@ -23,18 +23,21 @@ def plan_from_request(
     stop_refs: Sequence[str] = (),
     *,
     score: Score | None = None,
+    verse_ends: Collection[Location] = (),
 ) -> BoundaryPlan:
     """`locations` is `advice` and `score.words` in the same order, so a
     caller's stop-sign class and a caller's word ref both index it."""
-    requested = _parse_stop_signs(stop_signs)
+    requested, stop_at_verse = _parse_stop_signs(stop_signs)
     at_refs = frozenset(stop_refs)
 
     sakt = _sakt_flags(score, len(advice))
     junctions = []
     for index, word_advice in enumerate(advice):
         last = index == len(advice) - 1
-        asked = (word_advice is not None and word_advice in requested) or (
-            str(locations[index]) in at_refs
+        asked = (
+            (stop_at_verse and locations[index] in verse_ends)
+            or (word_advice is not None and word_advice in requested)
+            or str(locations[index]) in at_refs
         )
         if last:
             junctions.append(Junction.EDGE)
@@ -48,10 +51,16 @@ def plan_from_request(
     return BoundaryPlan(tuple(junctions))
 
 
-def _parse_stop_signs(stop_signs: Sequence[str]) -> set[StopAdvice]:
+def _parse_stop_signs(
+    stop_signs: Sequence[str],
+) -> tuple[set[StopAdvice], bool]:
     requested: set[StopAdvice] = set()
     unknown: list[str] = []
+    stop_at_verse = False
     for sign in stop_signs:
+        if sign == "verse":
+            stop_at_verse = True
+            continue
         try:
             requested.add(StopAdvice(sign))
         except ValueError:
@@ -59,9 +68,9 @@ def _parse_stop_signs(stop_signs: Sequence[str]) -> set[StopAdvice]:
     if unknown:
         raise UnknownStopError(
             f"unknown stop sign {sorted(unknown)}; expected some of "
-            f"{[m.value for m in StopAdvice]}"
+            f"{['verse', *(m.value for m in StopAdvice)]}"
         )
-    return requested
+    return requested, stop_at_verse
 
 
 def all_join(word_count: int) -> BoundaryPlan:

--- a/quranic_phonemizer/session/boundaries.py
+++ b/quranic_phonemizer/session/boundaries.py
@@ -5,7 +5,7 @@ the one call site that hands it the assembled request's own words.
 """
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from ..engine.boundary_plan import plan_from_request
 from ..model.address import BoundaryPlan, Location
@@ -20,7 +20,9 @@ def resolve_boundaries(
     *,
     stop_signs: Sequence[str] = (),
     stop_refs: Sequence[str] = (),
+    verse_ends: Collection[Location] = (),
 ) -> BoundaryPlan:
     return plan_from_request(
-        advice, locations, stop_signs, stop_refs, score=score
+        advice, locations, stop_signs, stop_refs,
+        score=score, verse_ends=verse_ends,
     )

--- a/quranic_phonemizer/session/core.py
+++ b/quranic_phonemizer/session/core.py
@@ -63,12 +63,14 @@ def phonemize_request(
         for stop_ref in stop_refs
         for location in recitation.corpus.locations(stop_ref)
     )
+    verse_ends = recitation.corpus.verse_ends(locations)
     boundaries = resolve_boundaries(
         built.inscription.advice,
         locations,
         built.score,
         stop_signs=stop_signs,
         stop_refs=resolved_stop_refs,
+        verse_ends=verse_ends,
     )
     performance = recitation.perform(
         built.score, boundaries, selection=selection
@@ -81,7 +83,7 @@ def phonemize_request(
         },
         verse_ends=frozenset(
             recitation.corpus.public_ref(location)
-            for location in recitation.corpus.verse_ends(locations)
+            for location in verse_ends
         ),
         public_refs=tuple(
             recitation.corpus.public_ref(location) for location in locations

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -172,6 +172,7 @@ def test_every_document_is_the_native_serialization():
             "hafs",
             "uthmani",
             (
+                "verse",
                 "preferred_continue",
                 "preferred_stop",
                 "optional_stop",
@@ -184,6 +185,7 @@ def test_every_document_is_the_native_serialization():
             "hafs",
             "indopak",
             (
+                "verse",
                 "preferred_continue",
                 "preferred_stop",
                 "optional_stop",
@@ -193,7 +195,7 @@ def test_every_document_is_the_native_serialization():
                 "permitted_stop",
             ),
         ),
-        ("warsh", "uthmani", ("optional_stop",)),
+        ("warsh", "uthmani", ("verse", "optional_stop")),
     ],
 )
 def test_stop_catalogues_are_configuration_scoped(riwayah, script, expected):
@@ -233,6 +235,25 @@ def test_warsh_requests_and_word_refs_use_its_source_coordinates():
     )
 
 
+@pytest.mark.parametrize(
+    ("reader", "ref", "verse_final_ref"),
+    [
+        (Phonemizer(), "1:4-1:5", "1:4:3"),
+        (Phonemizer(riwayah="warsh"), "1:3-1:4", "1:3:3"),
+    ],
+)
+def test_verse_stop_is_published_and_stops_at_each_source_ayah(
+    reader, ref, verse_final_ref
+):
+    assert "verse" in reader.available_stop_signs
+    joined = reader.analyse(ref)
+    stopped = reader.analyse(ref, stop_signs=("verse",))
+    word = next(word for word in joined.words if word.ref == verse_final_ref)
+
+    assert joined.boundaries[word.after_boundary_id.value].state is BoundaryState.JOIN
+    assert stopped.boundaries[word.after_boundary_id.value].state is BoundaryState.STOP
+
+
 def test_warsh_stop_sign_is_typed_and_requested_by_its_catalogue_name():
     reader = Phonemizer(riwayah="warsh")
     ref = "1:4-1:5"
@@ -266,7 +287,7 @@ def test_unavailable_stop_names_fail_before_boundary_resolution(monkeypatch):
         reader.analyse("1:1", stop_signs=("preferred_stop", "unknown"))
     assert str(caught.value) == (
         "['preferred_stop', 'unknown'] is not available for warsh/uthmani; "
-        "available stop signs: ['optional_stop']"
+        "available stop signs: ['verse', 'optional_stop']"
     )
 
 


### PR DESCRIPTION
## Stops
- Restore the legacy erse selector for every riwayah.
- Resolve verse endings in each script's native coordinates, including Hafs 1:4 and Warsh 1:3.

## README
- Replace the stale indexed analysis dump with the complete, self-contained 112:2 example.
- Show consumer-facing transformed cells, phonemes, changes, and rules without internal IDs.

## Verification
- python tools/gates.py --fast — 2,799 passed, 12 skipped, 3 xfailed; all static gates passed.