### PR TITLE
test(warsh): require complete projection closure

### DIFF
--- a/tests/conformance/test_warsh_cell_projection.py
+++ b/tests/conformance/test_warsh_cell_projection.py
@@ -5,20 +5,11 @@ import pytest
 
 from tools.warsh_projection_audit import audit
 
-KNOWN_PROJECTION_GAPS = {
-    "2:1", "3:1", "3:93", "7:1", "11:87", "12:90", "13:1", "26:1",
-    "27:29", "27:32", "27:39", "27:62", "27:64", "27:65", "27:66",
-    "28:1", "29:1", "30:1", "31:1", "32:1", "35:28", "37:52", "37:53",
-}
-
-
 @pytest.mark.slow
 def test_every_warsh_scalar_reaches_a_cell_or_boundary():
     result = audit()
     assert result.verses == 6214
-    assert {
-        failure.split(": ", 1)[0] for failure in result.failures
-    } == KNOWN_PROJECTION_GAPS
+    assert not result.failures
     assert len([char for char in result.scalars if char != " "]) == 62
     assert all(reach.routes for reach in result.scalars.values())
 

--- a/tests/conformance/test_warsh_cell_projection.py
+++ b/tests/conformance/test_warsh_cell_projection.py
@@ -5,6 +5,7 @@ import pytest
 
 from tools.warsh_projection_audit import audit
 
+
 @pytest.mark.slow
 def test_every_warsh_scalar_reaches_a_cell_or_boundary():
     result = audit()


### PR DESCRIPTION
## Summary

Remove the obsolete Warsh projection-gap allowlist and require the corpus audit to return no failures.

## Evidence

The slow 6,214-verse audit completed against the merged PR #77 tree with esult.failures == []. The previous assertion failed only because it still expected 23 historical gaps that are now closed.

## Release impact

This makes the 3.0 release gate accurately reflect the current invariant: every non-space Warsh scalar reaches a word cell or spelled boundary route.